### PR TITLE
[NO-JIRA] GKE no longer supports 1.16.13-gke.401

### DIFF
--- a/gke/private_kubernetes/main.tf
+++ b/gke/private_kubernetes/main.tf
@@ -103,7 +103,7 @@ resource "google_container_node_pool" "node_pool" {
   location = var.location
   cluster  = google_container_cluster.circleci_cluster.name
 
-  version = "1.16.13-gke.401"
+  version = "1.16.13-gke.404"
 
   autoscaling {
     min_node_count = var.node_min
@@ -136,7 +136,7 @@ resource "google_container_cluster" "circleci_cluster" {
   location    = var.location
   provider    = google-beta
 
-  min_master_version = "1.16.13-gke.401"
+  min_master_version = "1.16.13-gke.404"
 
   network = var.network_uri
   # subnetwork               = var.subnet_uri


### PR DESCRIPTION
Currently if you try to create a new GKE cluster you'll get this error:
`Error: googleapi: Error 400: Master version "1.16.13-gke.401" is unsupported., badRequest`

GKE no longer supports 1.16.13-gke.401 for master nodes so terraform will fail
The current min is now 1.16.13-gke.404

This PR updates the min version for the master and the node pools. The differences between versions are security updates.

This shouldn't affect existing cluster master nodes as GKE will update master nodes to the latest k8s version automatically. Only affects new clusters.
[see here](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_cluster#min_master_version)

however, node pools may need to be drained and updated. At this time i'm unsure whats the best approach with GKE as they may already handle this for us. This will be determined before an update to staging