### PR TITLE
(RE-759) Add preflight module to bastion host

### DIFF
--- a/eks/bastion.tf
+++ b/eks/bastion.tf
@@ -116,6 +116,7 @@ resource "aws_instance" "bastion" {
     curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.14.10/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/bin/
     curl -LO https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv3.5.4/kustomize_v3.5.4_linux_amd64.tar.gz && tar xzf ./kustomize_v3.5.4_linux_amd64.tar.gz && sudo mv ./kustomize /usr/bin/
     curl -LO https://github.com/replicatedhq/kots/releases/download/v1.19.5/kots_linux_amd64.tar.gz && tar xzf kots_linux_amd64.tar.gz && sudo mv ./kots /usr/bin/kubectl-kots
+    curl -LO https://github.com/replicatedhq/troubleshoot/releases/download/v0.9.51/preflight_linux_amd64.tar.gz && tar xzf preflight_linux_amd64.tar.gz && sudo mv ./preflight /usr/bin/kubectl-preflight
   EOF
 
   key_name               = aws_key_pair.bastion_key[0.0].key_name

--- a/gke/private_kubernetes/extra-vms.tf
+++ b/gke/private_kubernetes/extra-vms.tf
@@ -30,6 +30,7 @@ resource "google_compute_instance" "bastion" {
     "curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.14.10/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/bin/",
     "echo \"KUBECONFIG=/etc/kube.config gcloud container clusters get-credentials --internal-ip --region ${var.location} ${var.unique_name}-k8s-cluster && ( [ -e /home/ubuntu/.config ] && sudo chown -R ubuntu /home/ubuntu/.config ) && sudo chmod 0644 /etc/kube.config \" > update-kubeconfig && chmod +x update-kubeconfig && sudo mv ./update-kubeconfig /usr/bin/update-kubeconfig && update-kubeconfig",
     "curl -LO https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv3.5.4/kustomize_v3.5.4_linux_amd64.tar.gz && tar xzf ./kustomize_v3.5.4_linux_amd64.tar.gz && sudo mv ./kustomize /usr/bin/",
-    "curl -LO https://github.com/replicatedhq/kots/releases/download/v1.19.4/kots_linux_amd64.tar.gz && tar xzf kots_linux_amd64.tar.gz && sudo mv ./kots /usr/bin/kubectl-kots"
+    "curl -LO https://github.com/replicatedhq/kots/releases/download/v1.19.4/kots_linux_amd64.tar.gz && tar xzf kots_linux_amd64.tar.gz && sudo mv ./kots /usr/bin/kubectl-kots",
+    "curl -LO https://github.com/replicatedhq/troubleshoot/releases/download/v0.9.51/preflight_linux_amd64.tar.gz && tar xzf preflight_linux_amd64.tar.gz && sudo mv ./preflight /usr/bin/kubectl-preflight"
   ])
 }


### PR DESCRIPTION
This was causing some issues in the ox-bot testing workflow
where using krew to install this left behind a large amount of
artifacts. This resulted in OOS issues. This should be pre-installed
on the bastion host and version controlled, same as the kots version.