### PR TITLE
[SERVER-527] update EKS cluster version and node groups to 1.18

### DIFF
--- a/eks/cluster.tf
+++ b/eks/cluster.tf
@@ -8,7 +8,7 @@ data "aws_eks_cluster_auth" "cluster" {
 
 locals {
   cluster_name = "${var.basename}-cci-cluster"
-  k8s_version = "1.18"
+  k8s_version  = "1.18"
 }
 
 provider "kubernetes" {


### PR DESCRIPTION
Updates from previous version require cycling the pods to get reality check running again, but otherwise it is a seamless update