### PR TITLE
Simplify Google Auth

### DIFF
--- a/gke/README.md
+++ b/gke/README.md
@@ -91,7 +91,7 @@ gcloud container clusters get-credentials [CLUSTER NAME] \
     `allowed-external` rule to include your personal IP.
 13. Verify that the credentials were added by running the following command:
     `kubectl config get-contexts` This should return a list of contexts with an
-asterix beside the active context.
+asterisk beside the active context.
 
 [user default application credentials]: https://cloud.google.com/sdk/gcloud/reference/auth/application-default
 

--- a/gke/README.md
+++ b/gke/README.md
@@ -52,8 +52,14 @@ curl https://kots.io/install | bash
 
 ## Deploy GKE Infrastructure with Terraform
 
-1. Configure terraform to use Service Account Credentials
-    `export GOOGLE_APPLICATION_CREDENTIALS="<path to SAkey.json>"`
+1. Configure Google Cloud credentials. You can do this in one of two ways:
+    * Set up [user default application credentials]  via `gcloud auth
+      application-default login`. You may use the `--project` flag to select a
+GCP project.
+    * Use service account credentials. First configure environment variables
+      `export GOOGLE_APPLICATION_CREDENTIALS="<path to SAkey.json>"` and then
+activate your service account via `gcloud auth activate-service-account
+--key-file=$GOOGLE_APPLICATION_CREDENTIALS`
 2. Choose a base name 
     `export BASENAME=<name>`  
     Suggested `<yourname>-dev`
@@ -86,6 +92,8 @@ gcloud container clusters get-credentials [CLUSTER NAME] \
 13. Verify that the credentials were added by running the following command:
     `kubectl config get-contexts` This should return a list of contexts with an
 asterix beside the active context.
+
+[user default application credentials]: https://cloud.google.com/sdk/gcloud/reference/auth/application-default
 
 ## Generate Certificate (optional)
 

--- a/gke/main.tf
+++ b/gke/main.tf
@@ -55,7 +55,6 @@ module "nomad" {
   project_loc             = var.project_loc
   project_id              = var.project_id
   basename                = var.basename
-  service_account         = var.service_account
   nomad_count             = var.nomad_count
   ssh_enabled             = var.nomad_ssh_enabled
   ssh_allowed_cidr_blocks = var.allowed_cidr_blocks

--- a/gke/nomad/main.tf
+++ b/gke/nomad/main.tf
@@ -1,13 +1,11 @@
 # Provider with service account credentials
 provider "google" {
-  region      = var.project_loc
-  project     = var.project_id
-  credentials = var.service_account
+  region  = var.project_loc
+  project = var.project_id
 }
 
 # Provider with service account credentials
 provider "google-beta" {
-  region      = var.project_loc
-  project     = var.project_id
-  credentials = var.service_account
+  region  = var.project_loc
+  project = var.project_id
 }

--- a/gke/nomad/main.tf
+++ b/gke/nomad/main.tf
@@ -1,10 +1,8 @@
-# Provider with service account credentials
 provider "google" {
   region  = var.project_loc
   project = var.project_id
 }
 
-# Provider with service account credentials
 provider "google-beta" {
   region  = var.project_loc
   project = var.project_id

--- a/gke/nomad/variables.tf
+++ b/gke/nomad/variables.tf
@@ -20,12 +20,6 @@ variable "namespace" {
   description = "(Optional) The namespace of your CircleCI deployment in an existing cluster"
 }
 
-variable "service_account" {
-  type        = string
-  default     = null
-  description = "Path to json file for service account that will deploy resources. If not specified will default to $GOOGLE_APPLICATION_CREDENTIALS"
-}
-
 variable "nomad_count" {
   type        = number
   default     = 1

--- a/gke/terraform.tf
+++ b/gke/terraform.tf
@@ -8,15 +8,13 @@ terraform {
 
 # Provider with service account credentials
 provider "google" {
-  region      = var.project_loc
-  project     = var.project_id
-  credentials = var.service_account
+  region  = var.project_loc
+  project = var.project_id
 }
 
 # Provider with service account credentials
 provider "google-beta" {
-  region      = var.project_loc
-  project     = var.project_id
-  credentials = var.service_account
+  region  = var.project_loc
+  project = var.project_id
 }
 

--- a/gke/variables.tf
+++ b/gke/variables.tf
@@ -14,12 +14,6 @@ variable "basename" {
   description = "Name of deployment to be used as a base for naming resources."
 }
 
-variable "service_account" {
-  type        = string
-  default     = null
-  description = "Path to json file for service account that will deploy resources. If not specified will default to $GOOGLE_APPLICATION_CREDENTIALS"
-}
-
 variable "node_spec" {
   type        = string
   default     = "n1-standard-8"


### PR DESCRIPTION
**Problem**
We currently demand that GCP users specify a service account credentials file. These is fairly rigid in that it requires users to create a service account with sufficient permissions and an associated key file even if they already have sufficient permissions themselves and application default credentials set up.

**Solution**
Use the Terraform google provides built-in credential discovery and remove the explicit need to specify a service-account file.

**Test Checklist**
- [x] Verify `terraform apply` works with application default credentials
- [x] Verify `terraform apply` still works with a service account with the supplied instructions
- [x] Verify the rich-diff of the markdown change renders ok (ie. the markdown is well formatted)

**Post merge checklist**
- [ ] Update variables and documentation for dogfood & staging