### PR TITLE
(RE-779) Update kots versions

### DIFF
--- a/eks/bastion.tf
+++ b/eks/bastion.tf
@@ -115,7 +115,7 @@ resource "aws_instance" "bastion" {
     # Kubernetes Tooling
     curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.14.10/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/bin/
     curl -LO https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv3.5.4/kustomize_v3.5.4_linux_amd64.tar.gz && tar xzf ./kustomize_v3.5.4_linux_amd64.tar.gz && sudo mv ./kustomize /usr/bin/
-    curl -LO https://github.com/replicatedhq/kots/releases/download/v1.19.5/kots_linux_amd64.tar.gz && tar xzf kots_linux_amd64.tar.gz && sudo mv ./kots /usr/bin/kubectl-kots
+    curl -LO https://github.com/replicatedhq/kots/releases/download/v1.24.1/kots_linux_amd64.tar.gz && tar xzf kots_linux_amd64.tar.gz && sudo mv ./kots /usr/bin/kubectl-kots
     curl -LO https://github.com/replicatedhq/troubleshoot/releases/download/v0.9.51/preflight_linux_amd64.tar.gz && tar xzf preflight_linux_amd64.tar.gz && sudo mv ./preflight /usr/bin/kubectl-preflight
   EOF
 

--- a/gke/private_kubernetes/extra-vms.tf
+++ b/gke/private_kubernetes/extra-vms.tf
@@ -30,7 +30,7 @@ resource "google_compute_instance" "bastion" {
     "curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.14.10/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/bin/",
     "echo \"KUBECONFIG=/etc/kube.config gcloud container clusters get-credentials --internal-ip --region ${var.location} ${var.unique_name}-k8s-cluster && ( [ -e /home/ubuntu/.config ] && sudo chown -R ubuntu /home/ubuntu/.config ) && sudo chmod 0644 /etc/kube.config \" > update-kubeconfig && chmod +x update-kubeconfig && sudo mv ./update-kubeconfig /usr/bin/update-kubeconfig && update-kubeconfig",
     "curl -LO https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv3.5.4/kustomize_v3.5.4_linux_amd64.tar.gz && tar xzf ./kustomize_v3.5.4_linux_amd64.tar.gz && sudo mv ./kustomize /usr/bin/",
-    "curl -LO https://github.com/replicatedhq/kots/releases/download/v1.19.4/kots_linux_amd64.tar.gz && tar xzf kots_linux_amd64.tar.gz && sudo mv ./kots /usr/bin/kubectl-kots",
+    "curl -LO https://github.com/replicatedhq/kots/releases/download/v1.24.1/kots_linux_amd64.tar.gz && tar xzf kots_linux_amd64.tar.gz && sudo mv ./kots /usr/bin/kubectl-kots",
     "curl -LO https://github.com/replicatedhq/troubleshoot/releases/download/v0.9.51/preflight_linux_amd64.tar.gz && tar xzf preflight_linux_amd64.tar.gz && sudo mv ./preflight /usr/bin/kubectl-preflight"
   ])
 }


### PR DESCRIPTION
We are using an older version of kots that consistently fails at
applying our current replicated releases due to annotations being added
to all kubernetes resources regardless of if they are mutable or
immutable.

Later versions of kots no longer add this annotation and we
should use them instead. This commit bumps the version of kots to the
latest version as of this commit.