### PR TITLE
[NO JIRA] replacing hardcoded node number values with variables

### DIFF
--- a/eks/cluster.tf
+++ b/eks/cluster.tf
@@ -42,10 +42,10 @@ module "eks-cluster" {
   node_groups = {
     circleci-server = {
       version                       = local.k8s_version
-      instance_type                 = "m4.2xlarge"
-      max_capacity                  = 5
-      min_capacity                  = 4
-      desired_capacity              = 4
+      instance_type                 = var.instance_type
+      max_capacity                  = var.max_capacity
+      min_capacity                  = var.min_capacity
+      desired_capacity              = var.desired_capacity
       additional_security_group_ids = [aws_security_group.eks_nomad_sg[0].id]
     }
   }

--- a/eks/terraform.tfvars.template
+++ b/eks/terraform.tfvars.template
@@ -27,3 +27,9 @@ k8s_administrators  = []    # add any AWS users here who should also have access
 
 nomad_count   = 1
 nomad_ssh_key = null  # Set to valid SSH public key to enable SSH access to nomad clients
+
+# Cluster node details - uncomment to manage node type and numbers. Below are the default values so if these are fine no need to uncomment
+# instance_type      = "m4.xlarge"
+# max_capacity       = 5
+# min_capacity       = 4
+# desired_capacity   = 4

--- a/eks/variables.tf
+++ b/eks/variables.tf
@@ -93,3 +93,27 @@ variable "nomad_ssh_key" {
   default     = null
   description = "SSH key to authenticate access to Nomad clients. If not set SSH access is disabled"
 }
+
+variable "instance_type" {
+  type        = string
+  default     = "m4.2xlarge"
+  description = "The machine types used to create nodes"
+}
+
+variable "max_capacity" {
+  type        = number
+  default     = 5
+  description = "The maximun number of worker nodes in the cluster"
+}
+
+variable "min_capacity" {
+  type        = number
+  default     = 4
+  description = "The minimum number of worker nodes in the cluster"
+}
+
+variable "desired_capacity" {
+  type        = number
+  default     = 4
+  description = "The desired number of worker nodes in the cluster"
+}

--- a/eks/variables.tf
+++ b/eks/variables.tf
@@ -96,7 +96,7 @@ variable "nomad_ssh_key" {
 
 variable "instance_type" {
   type        = string
-  default     = "m4.2xlarge"
+  default     = "m4.xlarge"
   description = "The machine types used to create nodes"
 }
 


### PR DESCRIPTION
The number of nodes and the machine type used was hardcoded to the cluster.tf file the eks dir.

This PR replaces those values with variables so the user may tune the cluster specs to their needs from the tfvars file. defaults have been set which match our existing hardcoded values.