### PR TITLE
[No JIRA] Documentation Updates

### DIFF
--- a/eks/README.md
+++ b/eks/README.md
@@ -11,12 +11,8 @@ following CLIs installed:
 
 * [terraform] (tested with 0.13.5)
 * [kubectl] (tested with 1.14.6)
-* [kustomize] (tested with 3.6.1)
-* [helm] (tested with 3.0.1)
 * [awscli] (tested with 1.16.261)
-* [kots]
 * [server-keysets]
-* Optional: [GPG](https://gpgtools.org/)
 
 
 Additionally you will require the following permissions and access in order to
@@ -97,7 +93,7 @@ certbot certonly \
 This will create a certificate along with chain of intermediate
 certificates in `eks-config/live/$domain/fullchain.pem` and private
 key in `eks-config/live/$domain/privkey.pem`. These files can be used in
-Kots config to secure your installations with TLS.
+your Server 3.0 config to secure your installations with TLS.
 
 You need a public DNS record in Route53 for your secondary domain if your
 hostname already contains a subdomain: If you want to register your
@@ -120,10 +116,7 @@ record for `dev.example.com` for this step to succeed.
 
 <!-- Links -->
 [terraform]: https://releases.hashicorp.com/terraform/0.13.5/
-[kubectl]: https://storage.googleapis.com/kubernetes-release/release/v1.14.6/bin/darwin/amd64/kubectl
-[kustomize]: https://github.com/kubernetes-sigs/kustomize/releases/tag/kustomize%2Fv3.6.1
-[helm]: https://get.helm.sh/helm-v3.0.1-linux-amd64.tar.gz
+[kubectl]: https://kubernetes.io/docs/tasks/tools/install-kubectl/
 [awscli]: https://aws.amazon.com/cli/
-[kots]: https://kots.io/kots-cli/getting-started/
 [server-keysets]: https://github.com/CircleCI-Public/server-keysets-cli#using-the-docker-container
 [aws-keypair-docs]: https://docs.aws.amazon.com/cli/latest/userguide/cli-services-ec2-keypairs.html

--- a/eks/README.md
+++ b/eks/README.md
@@ -31,12 +31,6 @@ configure the CircleCI Server application:
 3. Assume going forward that all paths specified are relative to the root of
    the `server-terraform` repo.
 
-### Optional
-The following steps are optional if the IAM secret key needs to be encrypted in the terraform state file
-1. Generate a PGP key: `gpg --full-generate-key`
-2. Get a copy of the base64 encoded public key: `gpg --export <keyname> | base64 | pbcopy`
-3. Use the base64 encoded public key to populate the `pgp_key` terraform variable
-
 ## Deploy EKS Infrastructure with Terraform
 
 1. Choose a basename for your EKS installation and set a BASENAME environment

--- a/eks/terraform.tfvars.template
+++ b/eks/terraform.tfvars.template
@@ -10,11 +10,7 @@ bastion_key      = ""        # cat the public ssh key to use for the bastion hos
 # The default is ["0.0.0.0/0"], which implements no IP restrictions
 # allowed_cidr_blocks = [""]
 
-force_destroy    = false    # Forces destroy of the S3 data bucket on `terraform destroy`.  Useful as true for development purposes.  Data in bucket will be unrecoverable
-
-# Optional PGP key used to encrypt AWS IAM secret access key at rest
-# if left blank secret key will be unencrypted in terraform output and state files 
-pgp_key          = null       
+force_destroy    = false    # Forces destroy of the S3 data bucket on `terraform destroy`.  Useful as true for development purposes.  Data in bucket will be unrecoverable   
 
 k8s_administrators  = []    # add any AWS users here who should also have access to the cluster
 #  Read more here: https://docs.aws.amazon.com/eks/latest/userguide/add-user-role.html

--- a/eks/variables.tf
+++ b/eks/variables.tf
@@ -32,10 +32,6 @@ variable "bastion_key" {
   default = ""
 }
 
-variable "pgp_key" {
-  default = null
-}
-
 variable "aws_subnet_cidr_block" {
   default = ["10.0.0.0/16"]
 }

--- a/gke/README.md
+++ b/gke/README.md
@@ -10,10 +10,7 @@ following CLIs installed:
 
 * [terraform] (tested with 0.13.5)
 * [kubectl] (tested with 1.14.6)
-* [kustomize] (tested with 3.6.1)
-* [helm] (tested with 3.0.1)
 * [gcloud] (tested with 301.0.0)
-* [kots]
 * [server-keysets]
   (Actual installation is unnecessary; the Docker image will be pulled
   automatically when you attempt to use it.)
@@ -131,11 +128,7 @@ around.
 
 <!-- Links -->
 [terraform]: https://releases.hashicorp.com/terraform/0.13.5/
-[kubectl]: https://storage.googleapis.com/kubernetes-release/release/v1.14.6/bin/darwin/amd64/kubectl
-[kustomize]: https://github.com/kubernetes-sigs/kustomize/releases/tag/kustomize%2Fv3.6.1
-[helm]: https://get.helm.sh/helm-v3.0.1-linux-amd64.tar.gz
-[awscli]: https://aws.amazon.com/cli/
-[kots]: https://kots.io/kots-cli/getting-started/
+[kubectl]: https://kubernetes.io/docs/tasks/tools/install-kubectl/
 [server-keysets]: https://github.com/CircleCI-Public/server-keysets-cli#using-the-docker-container
 [gcloud]: https://cloud.google.com/sdk/install
 [gcloud-service-account-keys]: https://cloud.google.com/docs/authentication/production#creating_a_service_account


### PR DESCRIPTION
Changes:
- remove references to kots, kustomize and helm
- eks no longer requires pgp key
- the link for kubectl assumes an OS. replacing with more general
instructions