### PR TITLE
Fix initial node count

### DIFF
--- a/gke/variables.tf
+++ b/gke/variables.tf
@@ -58,7 +58,7 @@ variable "node_auto_upgrade" {
 
 variable "initial_nodes" {
   type        = number
-  default     = 1
+  default     = 3
   description = "Number of nodes per region at deployment."
 }
 


### PR DESCRIPTION
The default value causes the preflight check to fail. That's not looking good, let's make sure to provision enough K8s nodes from the outset.