### PR TITLE
Remove Service Account permissions from Nomad

### DIFF
--- a/gke/README.md
+++ b/gke/README.md
@@ -3,7 +3,7 @@
 ## Assumptions and Requirements
 
 It is assumed that a Google Cloud project exists and that the deployer
-has permissions to create, modify, and delete resources and IAM accounts. 
+has permissions to create, modify, and delete resources and Service Accounts.
 
 To deploy the infrastructure and application you will need to have the
 following CLIs installed:
@@ -42,7 +42,7 @@ curl https://kots.io/install | bash
 
 1. Install any missing CLI tools listed above. Ensure access to listed
    services.
-2. Clone `server-terraform` repository to your machine.  
+2. Clone `server-terraform` repository to your machine.
 	`git clone git@github.com:circleci/server-terraform.git`
 3. Assume going forward that all paths specified are relative to the root of
    the `server-terraform` repo.
@@ -57,8 +57,8 @@ GCP project.
       `export GOOGLE_APPLICATION_CREDENTIALS="<path to SAkey.json>"` and then
 activate your service account via `gcloud auth activate-service-account
 --key-file=$GOOGLE_APPLICATION_CREDENTIALS`
-2. Choose a base name 
-    `export BASENAME=<name>`  
+2. Choose a base name
+    `export BASENAME=<name>`
     Suggested `<yourname>-dev`
 3. Navigate to `./gke`
 4. Create a bucket for terraform state `gsutil mb
@@ -107,7 +107,7 @@ certbot certonly \
     --dns-google-credentials ${GOOGLE_APPLICATION_CREDENTIALS} \
     --config-dir=gke-config \
     --work-dir=gke-work \
-    --logs-dir=gke-logs \ 
+    --logs-dir=gke-logs \
     -d $domain
 ```
 
@@ -119,6 +119,17 @@ Kots config to secure your installations with TLS.
 ### Resources
 
 [Google Clouds Supported Resources Page]
+
+#### Service Account for Nomad clients
+
+By default we create a Service Account for the Nomad clients but we
+do not add any privileges to them. In the event an operator wants to
+assign privileges to the Nomad clients, they should do so through
+`nomad_service_account`.
+
+Please note that inherent risk of granting privileges to the Nomad clients
+as arbitrary code runs in them. This is an advanced feature that should only
+be used with the full understanding of the privileges being assigned.
 
 #### GCloud tip for machines and clusters that don't have external networking interfaces
 

--- a/gke/nomad/nomad.tf
+++ b/gke/nomad/nomad.tf
@@ -35,39 +35,10 @@ resource "google_service_account" "nomad_service_account" {
   display_name = "${local.basename}-nomad-sa"
   description  = "${local.basename} service account for CircleCI Server Nomad component"
 }
-resource "google_project_iam_member" "nomad_member_compute_admin" {
-  depends_on = [google_service_account.nomad_service_account]
-  role       = "roles/compute.admin"
-  member     = "serviceAccount:${google_service_account.nomad_service_account.email}"
-}
-resource "google_project_iam_member" "nomad_member_storage" {
-  depends_on = [google_service_account.nomad_service_account]
-  role       = "roles/storage.admin"
-  member     = "serviceAccount:${google_service_account.nomad_service_account.email}"
-}
-resource "google_project_iam_member" "nomad_member_logging" {
-  depends_on = [google_service_account.nomad_service_account]
-  role       = "roles/logging.admin"
-  member     = "serviceAccount:${google_service_account.nomad_service_account.email}"
-}
-resource "google_project_iam_member" "nomad_member_monitoring" {
-  depends_on = [google_service_account.nomad_service_account]
-  role       = "roles/monitoring.admin"
-  member     = "serviceAccount:${google_service_account.nomad_service_account.email}"
-}
-resource "google_project_iam_member" "nomad_member_service_controller" {
-  depends_on = [google_service_account.nomad_service_account]
-  role       = "roles/servicemanagement.serviceController"
-  member     = "serviceAccount:${google_service_account.nomad_service_account.email}"
-}
-resource "google_project_iam_member" "nomad_member_service_management" {
-  depends_on = [google_service_account.nomad_service_account]
-  role       = "roles/servicemanagement.admin"
-  member     = "serviceAccount:${google_service_account.nomad_service_account.email}"
-}
+
 
 resource "google_compute_instance_template" "nomad_template" {
-  # We've add this wait to ensure that 
+  # We've add this wait to ensure that
   depends_on = [time_sleep.wait_120_seconds]
 
   name_prefix  = "${local.basename}-nomad-template"


### PR DESCRIPTION
SERVER-102

I left the service account itself in case a given operator
wants to apply some privileges to the nomad clients. However,
by default, we don't need any of the previously defined permissions.
They were just a holdover and copy/paste error from the GKE cluster.