### PR TITLE
User management for GKE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@
 terraform.tfvars
 remote-state.tf
 terraform.tfstate
+terraform.tfstate.backup
+.terraform.lock.hcl
 
 # Mac
 .DS_Store

--- a/gke/README.md
+++ b/gke/README.md
@@ -49,6 +49,8 @@ curl https://kots.io/install | bash
 
 ## Deploy GKE Infrastructure with Terraform
 
+This assumes the default configuration with a private cluster behind a bastion host.
+
 1. Configure Google Cloud credentials. You can do this in one of two ways:
     * Set up [user default application credentials]  via `gcloud auth
       application-default login`. You may use the `--project` flag to select a
@@ -77,16 +79,21 @@ and removals.
 10. Once the plan has been verified, run command: `terraform apply` And when
     prompted, confirm the deployment. Deployment time can vary but has
 typically taken approximately ten minutes.
-11. Once deployment is complete, add the new GKE cluster to your local
-    Kubernetes configuration via gcloud by running the following command:
+11. Once deployment is complete, Terraform will display the name of the bastion host and the name and IP of the cluster. You can now connect to your bastion host:
+
+`gcloud compute ssh <bastion-host-name> --project <project-name> --region <region-name>`
+
+The `--project` and `--region` flags can be omitted if `gcloud` the default values configured during initialization can be used. If you have previously used service account credentials, switch back to use your user account credentials before connecting to the bastion: `gcloud auth login`.
+
+You will need to connect to the bastion whenever you need to access the cluster or some of its components.
+
+12. On the bastion, initialize gcloud: `gcloud init` – please make sure that you are using your own credentials and not the bastion host's Service Account. The Service Account doesn't have any relevant permissions and will prevent you from working effectively on the cluster.
+
+13. Add the new GKE cluster to the Kubernetes configuration via gcloud by running the following command:
 ```
-gcloud container clusters get-credentials [CLUSTER NAME] \
-     --region [CLUSTER REGION] \
-     --project [CLUSTER PROJECT]
+gcloud container clusters get-credentials [CLUSTER NAME]
 ```
-12. Navigate to "VPC Network" > "Firewall Rules" and update the
-    `allowed-external` rule to include your personal IP.
-13. Verify that the credentials were added by running the following command:
+14. Verify that the credentials were added by running the following command:
     `kubectl config get-contexts` This should return a list of contexts with an
 asterisk beside the active context.
 

--- a/gke/main.tf
+++ b/gke/main.tf
@@ -45,6 +45,7 @@ module "kube_private_cluster" {
   enable_istio                   = var.enable_istio
   enable_intranode_communication = var.enable_intranode_communication
   enable_dashboard               = var.enable_dashboard
+  private_endpoint               = var.private_k8s_endpoint
 
   network_uri = google_compute_network.circleci_net.self_link
   subnet_uri  = data.google_compute_subnetwork.circleci_net_subnet_data.self_link
@@ -59,6 +60,7 @@ module "nomad" {
   ssh_enabled             = var.nomad_ssh_enabled
   ssh_allowed_cidr_blocks = var.allowed_cidr_blocks
   network_name            = google_compute_network.circleci_net.name
+  nomad_sa_access         = var.nomad_sa_access
 }
 
 resource "google_storage_bucket" "data_bucket" {
@@ -69,7 +71,7 @@ resource "google_storage_bucket" "data_bucket" {
 }
 
 
-# Outputs 
+# Outputs
 
 output "cluster" {
   value = "${module.kube_private_cluster.cluster_name} (${module.kube_private_cluster.cluster_public_endpoint})"

--- a/gke/managing_user_access.md
+++ b/gke/managing_user_access.md
@@ -1,0 +1,110 @@
+# Managing Access to your Kubernetes cluster
+The following document assumes you have used the terraform scripts found in this repository to create a Kubernetes cluster for your CircleCI server installation. Below we go through our recommended approach to providing and managing user access.
+
+
+## Overview
+
+We recommend making only the bastion host accessible from the public internet. Thus, you can remove most risk of unauthorized access by simply stopping your bastion host while not in use. This will also give you two layers of access control:
+* Who can connect to the bastion host
+* What can a user do on the bastion host
+
+## Managing bastion host SSH access
+
+The bastion host has OS Login enabled which allows you to manage SSH access to the bastion using the IAM controls in GCP. Users with `roles/owner`, `roles/editor` or `roles/compute.instanceAdmin` permissions will automatically have administrator permissions, i.e. they may perform `sudo` commands on the bastion.  You can grant other users within the project access with the `roles/compute.osLogin` permission or sudo access with the `roles/compute.osAdminLogin` permission. Users should also have the `roles/iam.serviceAccountUser` role on the service account as this is the account the bastion host itself uses to authenticate against other services, e.g. the Kubernetes cluster. You can attach conditions to the role to ensure that users can impersonate the Service Account only on the bastion host.
+
+This approach has the advantages that you don't need to manage SSH keys manually and that deactivating an IAM user will also prevent them from connecting to the bastion host. For this to work, a user needs to use Google's `glcoud` tool. Assuming a user has initialized gcloud (`gcloud init`), they can simply connect to the bastion using
+
+`gcloud compute ssh <bastion-host-name> --project <project-name> --region <region-name>`
+
+The `--project` and `--region` flags can be omitted if `gcloud` there were default values configured during initialization that can be used.
+
+## Adding Users with Limited Resource Access
+You may not wish for each user to have access to all cluster resources. To finely tune user access we make use of kubernetes' role based access control ([RBAC]).
+In the following example we will create a role that will have limited access to a `develop` namespace and then map it to an IAM user. You will need to be a cluster administrator as detailed above to proceed with the following steps.
+
+On the bastion host, make sure that your `kubectl` config is up-to-date and that you have all the necessary permissions.
+
+1. First, we'll create a `role` that may only read pod data in the `develop` namespace.
+- create a file called `read-role.yaml` and add the following:
+```
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: pod-reader
+  namespace: develop
+rules:
+- apiGroups: [""] # "" indicates the core API group
+  resources: ["pods"]
+  verbs: ["list","get","watch"]
+- apiGroups: ["extensions","apps"]
+  resources: ["deployments"]
+  verbs: ["get", "list", "watch"]
+```
+
+- and then apply the role to your cluster:
+`kubectl apply -f read-role.yaml`
+
+3. Now we will create a `role-binding` on the email address of our user's Google Cloud account and the pod-reader role in the cluster to define their access level.
+- Create a file called `read-role-binding.yaml` and add the following: 
+```
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: pod-reader-binding
+  namespace: develop
+subjects:
+- kind: User
+  name: <user-email>
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: Role
+  name: pod-reader
+  apiGroup: rbac.authorization.k8s.io
+```
+
+- and then apply the role-binding to your cluster:
+`kubectl apply -f read-role-binding.yaml`
+
+
+Now your user will be able to access the cluster from the bastion but will only be able to view pod resources in the `develop` namespace.
+
+For more details on managing permissions, you may read Google's [RBAC] documentation.
+
+
+## Other Role Binding Subjects
+RoleBindings are not limited to Google Cloud IAM users. The following other subjects are supported:
+```
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: pod-reader-binding
+  namespace: develop
+subjects:
+# Google Cloud user account
+- kind: User
+  name: janedoe@example.com
+# Kubernetes service account
+- kind: ServiceAccount
+  name: johndoe
+# IAM service account
+- kind: User
+  name: test-account@test-project-123456.google.com.iam.gserviceaccount.com
+# Google Group
+- kind: Group
+  name: accounting-group@example.com
+roleRef:
+  kind: Role
+  name: pod-reader
+  apiGroup: rbac.authorization.k8s.io
+```
+
+However, to use Google Groups, the group referenced here needs to be itself a member of the Google Group `gke-security-groups@<yourdomain>`, which you will probably need to create.
+
+
+Sources and further reading:
+[Configuring role-based access control (official GKE guide)](https://cloud.google.com/kubernetes-engine/docs/how-to/role-based-access-control)
+[Intro to RBAC](https://www.eksworkshop.com/beginner/090_rbac/)
+[Using RBAC Authorization](https://kubernetes.io/docs/reference/access-authn-authz/rbac/)
+
+<!-- Links -->
+[RBAC]: https://kubernetes.io/docs/reference/access-authn-authz/rbac/

--- a/gke/nomad/nomad.tf
+++ b/gke/nomad/nomad.tf
@@ -36,7 +36,6 @@ resource "google_service_account" "nomad_service_account" {
   description  = "${local.basename} service account for CircleCI Server Nomad component"
 }
 
-
 resource "google_compute_instance_template" "nomad_template" {
   # We've add this wait to ensure that
   depends_on = [time_sleep.wait_120_seconds]
@@ -56,6 +55,10 @@ resource "google_compute_instance_template" "nomad_template" {
       cloud_provider = "GCP"
     }
   )
+
+  metadata = {
+    enable-oslogin = "TRUE"
+  }
 
   disk {
     source_image = "ubuntu-os-cloud/ubuntu-1604-lts"

--- a/gke/nomad/variables.tf
+++ b/gke/nomad/variables.tf
@@ -35,7 +35,13 @@ variable "ssh_allowed_cidr_blocks" {
 variable "ssh_enabled" {
   type        = bool
   default     = false
-  description = "If true, SSH access to Nomad clients is enabled. If enabled, use `gcloud compute ssh` to manage keys."
+  description = "If true, SSH access from the internet to Nomad clients is enabled. If enabled, use `gcloud compute ssh` to manage keys."
+}
+
+variable "nomad_sa_access" {
+  type        = string
+  default     = "allAuthenticatedUsers"
+  description = "Who can use the Nomad ServiceAccount, e.g. for managing SSH keys on Nomad clients. Can be `user:{emailid}` for a single user, `group:{emailid}` for a Google group, or `allAuthenticatedUsers` to allow all authenticated users"
 }
 
 variable "network_name" {

--- a/gke/private_kubernetes/extra-vms.tf
+++ b/gke/private_kubernetes/extra-vms.tf
@@ -20,6 +20,10 @@ resource "google_compute_instance" "bastion" {
     }
   }
 
+  metadata = {
+    enable-oslogin = "TRUE"
+  }
+
   network_interface {
     network = var.network_uri
 

--- a/gke/private_kubernetes/firewalls.tf
+++ b/gke/private_kubernetes/firewalls.tf
@@ -32,6 +32,7 @@ resource "google_compute_firewall" "allow_all_internal_network" {
 # health checks and internal network(s)
 #
 resource "google_compute_firewall" "allowed_external_cidr_blocks" {
+  count       = var.enable_bastion ? 0 : 1
   name        = "allowed-external-cidr-blocks-${var.unique_name}"
   description = "${var.unique_name} firewall rule for CircleCI Server cluster component"
   network     = var.network_uri
@@ -69,5 +70,5 @@ resource "google_compute_firewall" "allow_bastion" {
   }
 
   target_tags   = ["bastion-host"]
-  source_ranges = ["0.0.0.0/0"]
+  source_ranges = var.allowed_external_cidr_blocks
 }

--- a/gke/private_kubernetes/main.tf
+++ b/gke/private_kubernetes/main.tf
@@ -136,6 +136,9 @@ resource "google_container_node_pool" "node_pool" {
 
 
 ### GKE CLUSTER ###
+locals {
+  private_endpoint = var.enable_bastion ? true : var.private_endpoint
+}
 resource "google_container_cluster" "circleci_cluster" {
   depends_on  = [google_project_service.container_service]
   name        = "${var.unique_name}-k8s-cluster"
@@ -156,7 +159,7 @@ resource "google_container_cluster" "circleci_cluster" {
   private_cluster_config {
     master_ipv4_cidr_block  = var.master_address_range
     enable_private_nodes    = true
-    enable_private_endpoint = false
+    enable_private_endpoint = local.private_endpoint
   }
 
   ip_allocation_policy {
@@ -165,7 +168,7 @@ resource "google_container_cluster" "circleci_cluster" {
   master_authorized_networks_config {
     dynamic "cidr_blocks" {
       iterator = block
-      for_each = var.allowed_external_cidr_blocks
+      for_each = local.private_endpoint ? [] : var.allowed_external_cidr_blocks
       content {
         cidr_block   = block.value
         display_name = block.value

--- a/gke/private_kubernetes/variables.tf
+++ b/gke/private_kubernetes/variables.tf
@@ -1,6 +1,6 @@
 
 variable "allowed_external_cidr_blocks" {
-  type = list
+  type = list(any)
 }
 
 variable "unique_name" {
@@ -116,4 +116,8 @@ variable "network_uri" {
 }
 variable "subnet_uri" {
   type = string
+}
+
+variable "private_endpoint" {
+  type = bool
 }

--- a/gke/terraform.tfvars.template
+++ b/gke/terraform.tfvars.template
@@ -2,7 +2,6 @@ basename          = ""        # Prefix added to cluster resources
 project_id        = ""        # Name of the google cloud project
 project_loc       = ""        # Region to create cluster IE us-east1 
 
-
 node_spec         = "n1-standard-8"
 node_min          = 1
 node_max          = 9
@@ -13,16 +12,25 @@ node_auto_upgrade = true
 initial_nodes     = 1
 
 enable_nat                     = true
-enable_bastion                 = false
+enable_bastion                 = true
 enable_istio                   = false
 enable_intranode_communication = false
 enable_dashboard               = false
+private_endpoint               = true
 
-# The CIDR ranges that are allowed to access the Kubernetes cluster and Nomad
-# clients if `nomad_ssh_enabled` is true.  Developers, this is typically the
-# public IP address of your home/office network IE ["1.2.3.4/32"] The default
-# is ["0.0.0.0/0"], which implements no IP restrictions
-# allowed_cidr_blocks = []
+# The CIDR ranges that are allowed to access those components of your
+# installation that should be accessible via the public internet. By default
+# this is only the bastion host. Developers, this is typically the public IP
+# address of your home/office network IE [ "1.2.3.4/32" ]. By default, access is
+# only available through the bastion host.
+allowed_cidr_blocks = []
 
 nomad_count   = 1
-nomad_ssh_enabled = false # Set to true to allow SSH access to Nomad clients. Use `gcloud compute ssh` to manage keys
+
+# Set to true to allow SSH access to Nomad clients via the public internet.
+# Use `gcloud compute ssh` to manage keys
+nomad_ssh_enabled = false
+# Who can use the Nomad ServiceAccount, e.g. for managing SSH keys on Nomad
+# clients. Can be `user:{emailid}` for a single user, `group:{emailid}` for a
+# Google group, or `allAuthenticatedUsers` to allow all authenticated users
+nomad_sa_access = "allAuthenticatedUsers"

--- a/gke/variables.tf
+++ b/gke/variables.tf
@@ -71,7 +71,7 @@ variable "enable_nat" {
 variable "enable_bastion" {
   type        = bool
   default     = true
-  description = "Include a bastion/jump server in deployment."
+  description = "Include a bastion/jump server in deployment. You can restrict the range of IPs that can connect to the bastion using `allowed_cidr_blocks`"
 }
 
 variable "enable_istio" {
@@ -92,10 +92,16 @@ variable "enable_dashboard" {
   description = "Enable Kubernetes dashboard."
 }
 
+variable "private_k8s_endpoint" {
+  type        = bool
+  default     = true
+  description = "By default, the Kubernetes endpoint is only accessible via the bastion host. Set to false if you want access via the public internet. You can use IP whitelisting using `allowed_cidr_blocks` to tighten access for both cases."
+}
+
 variable "allowed_cidr_blocks" {
   type        = list(string)
-  default     = ["0.0.0.0/0"]
-  description = "List of blocks allowed to access the kubernetes cluster. This list also limits access to Nomad clients if `nomad_ssh_enabled` is true."
+  default     = []
+  description = "This configures the allowable source IP blocks, depending on your configuration to your bastion host and/or Kubernetes cluster and/or Nomad clients"
 }
 
 variable "nomad_count" {
@@ -106,5 +112,11 @@ variable "nomad_count" {
 variable "nomad_ssh_enabled" {
   type        = bool
   default     = false
-  description = "Enables SSH to Nomad clients. If enabled, use `gcloud compute ssh` to manage SSH keys"
+  description = "Enables SSH to Nomad clients. If enabled, use `gcloud compute ssh` to manage SSH keys. If you use a bastion host and a private endpoint, you can still connect to Nomad clients with this value set to `false` via the bastion host using their private IPs"
+}
+
+variable "nomad_sa_access" {
+  type        = string
+  default     = "allAuthenticatedUsers"
+  description = "Who can use the Nomad ServiceAccount, e.g. for managing SSH keys on Nomad clients. Can be `user:{emailid}` for a single user, `group:{emailid}` for a Google group, or `allAuthenticatedUsers` to allow all authenticated users"
 }


### PR DESCRIPTION
This commit enables proper and secure user management in GKE by ensuring
that:

* The configuration defaults to a bastion host
* SSH keys are managed via GCP IAM mechanisms
* Process around using K8s RBAC with GCP IAM is documented

To ensure that the bastion host is actually secure, the following
changes were added when using a bastion host:

* Access to bastion can be restriced using allowed CIDR blocks
* All other access via the public internet is removed when bastion is
  used
* Documentation was updated accordingly
