### PR TITLE
[WIP] SERVER 566 | Remove all permissions from EKS nodes

### DIFF
--- a/eks/.gitignore
+++ b/eks/.gitignore
@@ -4,3 +4,5 @@ remote-state.tf
 .terraform
 terraform.tfstate
 terraform.tfstate.backup
+.terraform.tfstate.lock.info
+.terraform.lock.hcl

--- a/eks/cluster.tf
+++ b/eks/cluster.tf
@@ -3,6 +3,21 @@ locals {
   k8s_version  = "1.18"
 }
 
+data "aws_eks_cluster" "cluster" {
+  name = module.eks-cluster.cluster_id
+}
+
+data "aws_eks_cluster_auth" "cluster" {
+  name = module.eks-cluster.cluster_id
+}
+
+provider "kubernetes" {
+  host                   = data.aws_eks_cluster.cluster.endpoint
+  cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
+  token                  = data.aws_eks_cluster_auth.cluster.token
+  load_config_file       = false
+}
+
 module "eks-cluster" {
   version                         = "13.0.0"
   source                          = "terraform-aws-modules/eks/aws"

--- a/eks/terraform.tf
+++ b/eks/terraform.tf
@@ -1,4 +1,3 @@
 provider "aws" {
-  version = "~> 3.0.0"
-  region  = var.aws_region
+  region = var.aws_region
 }

--- a/eks/versions.tf
+++ b/eks/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.0"
+    }
+  }
+}

--- a/eks/versions.tf
+++ b/eks/versions.tf
@@ -4,5 +4,9 @@ terraform {
       source  = "hashicorp/aws"
       version = "~> 3.0"
     }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 1.9"
+    }
   }
 }


### PR DESCRIPTION
The first step of least privilege is no privilege ⛔. This removes all additional privileges from EKS nodes. Instead we create IAM accounts with least privilege and pass them into each container.

There are some drive by changes in here:

- Made 0.14.0 compat changes (moved version from provider block into terraform require_providers block)
- Deleted unnecessary data blocks and kubernetes provider block

*Summary*
- Ticket: SERVER-566
- Change Type: 🚫 Security
- Testing Checklist:
  - [ ] Verify fresh install
  - [ ] Verify upgrade pathway
  - [ ] From an EKS node explicitly verify that only the necessary node credentials remain on the IMDS endpoint