### PR TITLE
Add separate Service Account to bastion host

### DIFF
--- a/gke/private_kubernetes/extra-vms.tf
+++ b/gke/private_kubernetes/extra-vms.tf
@@ -1,3 +1,10 @@
+### SERVICE ACCOUNT ###
+resource "google_service_account" "k8s_bastion_service_account" {
+  account_id   = "${var.unique_name}-k8s-bastion-sa"
+  display_name = "${var.unique_name}-k8s-bastion-sa"
+  description  = "${var.unique_name} service account for CircleCI Server bastion host"
+}
+
 resource "google_compute_instance" "bastion" {
   count                     = var.enable_bastion ? 1 : 0
   name                      = "${var.unique_name}-bastion"
@@ -20,7 +27,7 @@ resource "google_compute_instance" "bastion" {
   }
 
   service_account {
-    email  = google_service_account.k8s_service_account.email
+    email  = google_service_account.k8s_bastion_service_account.email
     scopes = ["cloud-platform"]
   }
 


### PR DESCRIPTION
The bastion host was using the GKE cluster's Service Account, which was way too
powerful. This adds a separate SA for the bastion. As we are using OS Login on
the bastion (see #29), this SA has no special permissions, ensuring that the user cannot
perform any actions outside their own permissions by impersonating the
instance's SA.

Tested:
[x] I can still SSH into the bastion
[x] I can still renew my credentials for kubectl and perform actions on the
    cluster (like deleting pods, editing deployments)
[x] I can still SSH into Nomad clients from the bastion
