### PR TITLE
Allow defining Kubernetes admins using Roles

### DIFF
--- a/eks/cluster.tf
+++ b/eks/cluster.tf
@@ -30,13 +30,16 @@ module "eks-cluster" {
   subnets                         = module.vpc.private_subnets
   cluster_enabled_log_types       = ["api", "audit", "authenticator", "controllerManager", "scheduler"]
   wait_for_cluster_cmd            = "for i in `seq 1 60`; do curl -k -s $ENDPOINT/healthz >/dev/null && exit 0 || true; sleep 5; done; echo TIMEOUT && exit 1"
-  map_roles = var.enable_bastion ? [
-    {
-      rolearn  = aws_iam_role.bastion_role[0].arn
-      username = "bastion"
-      groups   = ["system:masters"]
-    }
-  ] : []
+  map_roles = var.enable_bastion ? concat(
+    var.k8s_roles,
+    [
+      {
+        rolearn  = aws_iam_role.bastion_role.arn
+        username = "bastion"
+        groups   = ["system:masters"]
+      }
+    ]
+  ) : []
   map_users = var.k8s_administrators
 
   node_groups = {

--- a/eks/variables.tf
+++ b/eks/variables.tf
@@ -25,6 +25,10 @@ variable "k8s_administrators" {
   default = []
 }
 
+variable "k8s_roles" {
+  default = []
+}
+
 variable "force_destroy" {
   default = false
 }


### PR DESCRIPTION
Some users/companies login to AWS via SAML and that means that IAM roles are used to
identify them and not IAM users.