### PR TITLE
allow custom VPC CIDR addresses

### DIFF
--- a/eks/nomad.tf
+++ b/eks/nomad.tf
@@ -5,7 +5,7 @@ module "nomad" {
   nomad_instance_type     = var.nomad_instance_type
   ssh_key                 = var.nomad_ssh_key
   ssh_allowed_cidr_blocks = var.allowed_cidr_blocks
-  aws_subnet_cidr_block   = var.aws_subnet_cidr_block
+  aws_subnet_cidr_block   = module.vpc.vpc_cidr_block
   sg_enabled              = var.sg_enabled
   nomad_count             = var.nomad_count
   ami_id                  = var.ubuntu_ami[var.aws_region]

--- a/eks/nomad/main.tf
+++ b/eks/nomad/main.tf
@@ -89,7 +89,7 @@ resource "aws_security_group" "nomad_sg" {
     from_port   = 4646
     to_port     = 4648
     protocol    = "tcp"
-    cidr_blocks = var.aws_subnet_cidr_block
+    cidr_blocks = [var.aws_subnet_cidr_block]
   }
 
   # For SSHing into a job as an end user (not operators)

--- a/eks/nomad/variables.tf
+++ b/eks/nomad/variables.tf
@@ -7,7 +7,7 @@ variable "nomad_instance_type" {
 }
 
 variable "aws_subnet_cidr_block" {
-  default = ["10.0.0.0/16"]
+  default = "10.0.0.0/16"
 }
 
 variable "sg_enabled" {

--- a/eks/variables.tf
+++ b/eks/variables.tf
@@ -44,10 +44,6 @@ variable "aws_vpc_private_cidr_blocks" {
   default = ["10.0.96.0/19", "10.0.128.0/19", "10.0.160.0/19"]
 }
 
-variable "aws_subnet_cidr_block" {
-  default = ["10.0.0.0/16"]
-}
-
 variable "allowed_cidr_blocks" {
   default = ["0.0.0.0/0"]
 }

--- a/eks/variables.tf
+++ b/eks/variables.tf
@@ -32,6 +32,18 @@ variable "bastion_key" {
   default = ""
 }
 
+variable "aws_vpc_cidr_block" {
+  default = "10.0.0.0/16"
+}
+
+variable "aws_vpc_public_cidr_blocks" {
+  default = ["10.0.0.0/19", "10.0.32.0/19", "10.0.64.0/19"]
+}
+
+variable "aws_vpc_private_cidr_blocks" {
+  default = ["10.0.96.0/19", "10.0.128.0/19", "10.0.160.0/19"]
+}
+
 variable "aws_subnet_cidr_block" {
   default = ["10.0.0.0/16"]
 }

--- a/eks/vpc.tf
+++ b/eks/vpc.tf
@@ -6,16 +6,16 @@ module "vpc" {
   source = "terraform-aws-modules/vpc/aws"
 
   name = "${var.basename}-circleci"
-  cidr = "10.0.0.0/16"
+  cidr = var.aws_vpc_cidr_block
 
   azs = data.aws_availability_zones.available.names
 
   # Public segment of VPC hosts public load balancers, nomad clients (for SSH access),
   # NAT gateways for the private segment.
-  public_subnets = ["10.0.0.0/19", "10.0.32.0/19", "10.0.64.0/19"]
+  public_subnets = var.aws_vpc_public_cidr_blocks
 
   # Private segment of VPC hosts internal load balancers, EKS pods and nodes.
-  private_subnets = ["10.0.96.0/19", "10.0.128.0/19", "10.0.160.0/19"]
+  private_subnets = var.aws_vpc_private_cidr_blocks
 
   enable_nat_gateway = true
   single_nat_gateway = true


### PR DESCRIPTION
In our AWS accounts we do lots of VPC Peering and the CircleCI VPC specifically is peered with other VPCs for service access, like GHE and our own private package repositories, so having the ability to customize the IP address ranges for the VPC is necessary.

In 96d8a0b removed the previous aws_subnet_cidr_block variable as it was only used on the Nomad security group to isolate access from the Nomad servers, which should be the whole VPC CIDR block anyway.