### PR TITLE
the Autoscaling module already sets the Name tag

### DIFF
--- a/eks/nomad/main.tf
+++ b/eks/nomad/main.tf
@@ -69,12 +69,7 @@ module "asg" {
       key                 = "Environment"
       value               = "circleci"
       propagate_at_launch = true
-    },
-    {
-      key                 = "Name"
-      value               = "${var.basename}-circleci-nomad-client"
-      propagate_at_launch = true
-    },
+    }
   ]
 }
 


### PR DESCRIPTION
The terraform-aws-autoscaling module automatically sets it's own "Name" tag so the nomad module shouldn't.

https://github.com/terraform-aws-modules/terraform-aws-autoscaling/blob/master/locals.tf#L2-L12

Without this whenever you run terraform plan it will show a difference every time.