### PR TITLE
Actually use the aws_profile variable

### DIFF
--- a/eks/terraform.tf
+++ b/eks/terraform.tf
@@ -1,4 +1,5 @@
 provider "aws" {
   version = "~> 3.0.0"
   region  = var.aws_region
+  profile = var.aws_profile != "" ? var.aws_profile : null
 }

--- a/eks/variables.tf
+++ b/eks/variables.tf
@@ -8,7 +8,8 @@ variable "basename" {
 }
 
 variable "aws_profile" {
-  default = ""
+  default     = ""
+  description = "If using multiple profiles locally in a multi-account setup, this allows you to choose one"
 }
 
 variable "aws_region" {


### PR DESCRIPTION
In our setup we have 10 profiles installed locally, each one pointing to
a different account. The CircleCI setup is in a specific non-default
one, so having the ability the specify it is needed, otherwise you need
to remember to run:

```
export AWS_PROFILE=profile_name
```