### PR TITLE
[SERVER-449] encrypting s3 bucket

### DIFF
--- a/eks/s3.tf
+++ b/eks/s3.tf
@@ -1,6 +1,61 @@
+data "aws_caller_identity" "current" {}
+
+resource "aws_kms_key" "data_bucket_key" {
+  description             = "This key is used to encrypt the data_bucket"
+  deletion_window_in_days = 10
+
+
+# This policy allows the root to manage the keys - needed for terraform to manage the keys and provides the cluster nodes with limited access to keys
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "kms:*"
+      ],
+      "Principal": { "AWS": [
+          "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
+        ]
+      },
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
+      "Action": [
+        "kms:Decrypt",
+        "kms:GenerateDataKey*"
+      ],
+      "Principal": { "AWS": [
+          "${module.eks-cluster.worker_iam_role_arn}"
+        ]
+      },
+      "Effect": "Allow",
+      "Resource": "*"
+    }
+  ]
+}
+EOF
+}
+
 resource "aws_s3_bucket" "data_bucket" {
   bucket        = "${var.basename}-data"
   force_destroy = var.force_destroy
+
+  cors_rule {
+    allowed_methods = ["GET"]
+    allowed_origins = ["*"]
+    max_age_seconds = 3600
+  }
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        kms_master_key_id = aws_kms_key.data_bucket_key.arn
+        sse_algorithm     = "aws:kms"
+      }
+    }
+  }
 
   tags = {
     Terraform     = "true"
@@ -10,3 +65,17 @@ resource "aws_s3_bucket" "data_bucket" {
     force_destroy = true
   }
 }
+
+
+output "user_arn" {
+  value = data.aws_caller_identity.current.arn
+}
+
+output "cluster_arn" {
+  value = module.eks-cluster.cluster_iam_role_arn
+}
+
+output "worker_arn" {
+  value = module.eks-cluster.worker_iam_role_arn
+}
+

--- a/eks/s3.tf
+++ b/eks/s3.tf
@@ -7,7 +7,7 @@ resource "aws_s3_bucket" "data_bucket" {
     allowed_origins = ["*"]
     max_age_seconds = 3600
   }
-  
+
   server_side_encryption_configuration {
     rule {
       apply_server_side_encryption_by_default {

--- a/eks/s3.tf
+++ b/eks/s3.tf
@@ -5,7 +5,7 @@ resource "aws_kms_key" "data_bucket_key" {
   deletion_window_in_days = 10
 
 
-# This policy allows the root to manage the keys - needed for terraform to manage the keys and provides the cluster nodes with limited access to keys
+  # This policy allows the root to manage the keys - needed for terraform to manage the keys and provides the cluster nodes with limited access to keys
   policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -65,17 +65,3 @@ resource "aws_s3_bucket" "data_bucket" {
     force_destroy = true
   }
 }
-
-
-output "user_arn" {
-  value = data.aws_caller_identity.current.arn
-}
-
-output "cluster_arn" {
-  value = module.eks-cluster.cluster_iam_role_arn
-}
-
-output "worker_arn" {
-  value = module.eks-cluster.worker_iam_role_arn
-}
-

--- a/eks/s3.tf
+++ b/eks/s3.tf
@@ -1,43 +1,3 @@
-data "aws_caller_identity" "current" {}
-
-resource "aws_kms_key" "data_bucket_key" {
-  description             = "This key is used to encrypt the data_bucket"
-  deletion_window_in_days = 10
-
-
-  # This policy allows the root to manage the keys - needed for terraform to manage the keys and provides the cluster nodes with limited access to keys
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": [
-        "kms:*"
-      ],
-      "Principal": { "AWS": [
-          "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
-        ]
-      },
-      "Effect": "Allow",
-      "Resource": "*"
-    },
-    {
-      "Action": [
-        "kms:Decrypt",
-        "kms:GenerateDataKey*"
-      ],
-      "Principal": { "AWS": [
-          "${module.eks-cluster.worker_iam_role_arn}"
-        ]
-      },
-      "Effect": "Allow",
-      "Resource": "*"
-    }
-  ]
-}
-EOF
-}
-
 resource "aws_s3_bucket" "data_bucket" {
   bucket        = "${var.basename}-data"
   force_destroy = var.force_destroy
@@ -47,12 +7,11 @@ resource "aws_s3_bucket" "data_bucket" {
     allowed_origins = ["*"]
     max_age_seconds = 3600
   }
-
+  
   server_side_encryption_configuration {
     rule {
       apply_server_side_encryption_by_default {
-        kms_master_key_id = aws_kms_key.data_bucket_key.arn
-        sse_algorithm     = "aws:kms"
+        sse_algorithm = "AES256"
       }
     }
   }


### PR DESCRIPTION
This PR adds encryption to our S3 bucket. 
Output-processor however has a hard-coded policy within it which is used for server jobs. execution team needs to do work however to add kms permissions to the policy within output-processor. Once that work is done then we may merge this PR.

Tests:
- [x] new cluster: works
- [x] update to an existing cluster: works 

How to test:
1. Spin up an instance of EKS using this branch
2. Deploy server 3.0 onto this cluster
3. Create a REPL to output-processor and apply the following to update the policy:
`(in-ns 'output-processing.storage)
(defn- aws-credentials-policy
  [build project aws-identity]
  (let [[bucket prefix] (str/split (artifacts-bucket) #"/" 2)
        build-id (-> @build :_id str)
        workspace-id (-> @build :workflows :workspace-id)
        project-root (storage-root build project prefix)
        test-results (:used-test-results @build)
        partition (aws-identity->partition aws-identity)]
    {"Version" "2012-10-17"
     "Statement"
     (filter some?
             [{"Effect" "Allow"
               "Action" ["s3:ListBucket"]
               "Resource" [(format "arn:%s:s3:::%s" partition bucket)]
               ;; Allow listing anything in the bucket, filenames aren't a big deal
               "Condition" {"StringLike" {"s3:prefix" [(format "%s/*" project-root)]}}}
              {"Effect" "Allow"
               "Action" ["s3:GetObject"
                         "s3:PutObject"
                         "s3:PutObjectTagging"
                         "s3:ListMultipartUploadParts"
                         "s3:AbortMultipartUpload"]
               "Resource" [;; Caches are global within a project
                           (format "arn:%s:s3:::%s/%s/global/*" partition bucket project-root)
                           ;; Workspaces are scoped by workspace ID
                           (format "arn:%s:s3:::%s/%s/workflows/workspaces/%s/*" partition bucket project-root workspace-id)
                           ;; Artifacts are scoped by build-id - note the trailing `-` to allow for parallel tasks
                           (format "arn:%s:s3:::%s/%s/%s-*" partition bucket project-root build-id)]}
              {"Effect" "Allow"
               "Action" ["kms:*"]
               "Resource" "*"}
              (when test-results
                {"Effect" "Allow"
                 "Action" ["s3:GetObject"]
                 "Resource" (format "arn:%s:s3:::%s/%s" partition (:bucket test-results) (:key test-results))})])}))`
4. run realitycheck