### PR TITLE
Add Calico network policy enforcement to GCP

### DIFF
--- a/gke/private_kubernetes/main.tf
+++ b/gke/private_kubernetes/main.tf
@@ -186,6 +186,9 @@ resource "google_container_cluster" "circleci_cluster" {
   #     minimum = 4
   #   }
   # }
+  network_policy {
+    enabled = true
+  }
 
   addons_config {
     horizontal_pod_autoscaling {
@@ -193,6 +196,9 @@ resource "google_container_cluster" "circleci_cluster" {
     }
     istio_config {
       disabled = var.enable_istio ? false : true
+    }
+    network_policy_config {
+      disabled = false
     }
   }
 


### PR DESCRIPTION
Adds [Calico](https://cloud.google.com/kubernetes-engine/docs/how-to/network-policy#using_network_policy_enforcement) as a network policy enforcer to GCP.

- Ticket: SERVER-565
- Change: Security enhancement
- Testing checklist:
  - [x] Created new GCP installation from scratch
  - [x] Verified network policy enforcement functions as expected