### PR TITLE
Restrict IAM permissions on EKS nodes

### DIFF
--- a/eks/.gitignore
+++ b/eks/.gitignore
@@ -4,3 +4,4 @@ remote-state.tf
 .terraform
 terraform.tfstate
 terraform.tfstate.backup
+.terraform.lock.hcl

--- a/eks/cluster.tf
+++ b/eks/cluster.tf
@@ -133,28 +133,121 @@ resource "aws_iam_role_policy_attachment" "output_processor_sts" {
 resource "aws_iam_policy" "vm-service-ec2" {
   name        = "${var.basename}-vm-service-ec2"
   description = "Security group for CircleCI Server VM Service EC2 instances"
-  policy      = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
+  policy      = <<-EOF
     {
-      "Effect": "Allow",
-      "Action": [
-        "ec2:RunInstances",
-        "ec2:CreateTags",
-        "ec2:TerminateInstances",
-        "ec2:CreateVolume",
-        "ec2:DeleteVolume",
-        "ec2:AttachVolume",
-        "ec2:DetachVolume"
-      ],
-      "Resource": [
-        "*"
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Action": "ec2:RunInstances",
+          "Effect": "Allow",
+          "Resource": [
+            "arn:aws:ec2:*::image/*",
+            "arn:aws:ec2:*::snapshot/*",
+            "arn:aws:ec2:*:*:key-pair/*",
+            "arn:aws:ec2:*:*:launch-template/*",
+            "arn:aws:ec2:*:*:network-interface/*",
+            "arn:aws:ec2:*:*:placement-group/*",
+            "arn:aws:ec2:*:*:volume/*",
+            "arn:aws:ec2:*:*:subnet/*",
+            "arn:aws:ec2:*:*:security-group/${aws_security_group.eks_nomad_sg[0].id}"
+          ]
+        },
+        {
+          "Action": "ec2:RunInstances",
+          "Effect": "Allow",
+          "Resource": "arn:aws:ec2:*:*:instance/*",
+          "Condition": {
+            "StringEquals": {
+              "aws:RequestTag/ManagedBy": "circleci-vm-service"
+            }
+          }
+        },
+        {
+          "Action": [
+            "ec2:CreateVolume"
+          ],
+          "Effect": "Allow",
+          "Resource": [
+            "arn:aws:ec2:*:*:volume/*"
+          ],
+          "Condition": {
+            "StringEquals": {
+              "aws:RequestTag/ManagedBy": "circleci-vm-service"
+            }
+          }
+        },
+        {
+          "Action": [
+            "ec2:Describe*"
+          ],
+          "Effect": "Allow",
+          "Resource": "*"
+        },
+        {
+          "Effect": "Allow",
+          "Action": [
+            "ec2:CreateTags"
+          ],
+          "Resource": "arn:aws:ec2:*:*:*/*",
+          "Condition": {
+            "StringEquals": {
+              "ec2:CreateAction" : "CreateVolume"
+            }
+          }
+        },
+        {
+          "Effect": "Allow",
+          "Action": [
+            "ec2:CreateTags"
+          ],
+          "Resource": "arn:aws:ec2:*:*:*/*",
+          "Condition": {
+            "StringEquals": {
+              "ec2:CreateAction" : "RunInstances"
+            }
+          }
+        },
+        {
+          "Action": [
+            "ec2:CreateTags",
+            "ec2:StartInstances",
+            "ec2:StopInstances",
+            "ec2:TerminateInstances",
+            "ec2:AttachVolume",
+            "ec2:DetachVolume",
+            "ec2:DeleteVolume"
+          ],
+          "Effect": "Allow",
+          "Resource": "arn:aws:ec2:*:*:*/*",
+          "Condition": {
+            "StringEquals": {
+              "ec2:ResourceTag/ManagedBy": "circleci-vm-service"
+            }
+          }
+        },
+        {
+          "Action": [
+            "ec2:RunInstances",
+            "ec2:StartInstances",
+            "ec2:StopInstances",
+            "ec2:TerminateInstances"
+          ],
+          "Effect": "Allow",
+          "Resource": "arn:aws:ec2:*:*:subnet/*",
+          "Condition": {
+            "StringEquals": {
+              "ec2:Vpc": "${module.vpc.vpc_arn}"
+            }
+          }
+        }
       ]
-    }
-  ]
+    } 
+  EOF
 }
-EOF
+
+resource "aws_iam_role_policy_attachment" "vm_ec2_access" {
+  role       = module.eks-cluster.worker_iam_role_name
+  policy_arn = aws_iam_policy.vm-service-ec2.arn
 }
 
 resource "aws_iam_policy" "external_dns" {
@@ -186,12 +279,6 @@ resource "aws_iam_policy" "external_dns" {
       ]
     }
   EOF
-}
-
-
-resource "aws_iam_role_policy_attachment" "vm_ec2_access" {
-  role       = module.eks-cluster.worker_iam_role_name
-  policy_arn = aws_iam_policy.vm-service-ec2.arn
 }
 
 resource "aws_iam_role_policy_attachment" "external_dns_route53_access" {


### PR DESCRIPTION
We're currently using instance profile (i.e. IMDS endpoint on EKS nodes) to give AWS credentials to Server services. We'd like to move completely away from this in the future, but in the interim this update to the policies restricts privileges to what is necessary to function.

- Ticket: [SERVER-566](https://circleci.atlassian.net/browse/SERVER-566)
- Change type: Security Improvement 🛡️ 
- Test checklist:
  - [x] Verify installation
  - [x] Passes reality check tests
  - [x] Verify that from vm-service it is only possible to control EC2 instances inside the VPC