### PR TITLE
set all nomad autoscaling values the same.  there is no autoscaling implemented anyway

### DIFF
--- a/eks/nomad/main.tf
+++ b/eks/nomad/main.tf
@@ -49,9 +49,9 @@ module "asg" {
   asg_name                  = "${var.basename}-circleci-nomad_asg"
   vpc_zone_identifier       = var.vpc_zone_identifier
   health_check_type         = "EC2"
-  min_size                  = 0
-  max_size                  = 1
-  desired_capacity          = 1
+  min_size                  = "${var.nomad_count}"
+  max_size                  = "${var.nomad_count}"
+  desired_capacity          = "${var.nomad_count}"
   wait_for_capacity_timeout = 0 # skip all Capacity Waiting behavior
 
   tags = [


### PR DESCRIPTION
On GKE the autoscaling resource is separate from the compute resource.  We have not implemented the autoscaler yet, so this is a non issue there.

In EKS, we provide users a variable to set their desired node count, but not the min and max.  This means they could set it outside the min/max range breaking things.  We could also expose those as variables for user config, but autoscaling is not implemented at all right now, so it would just be misleading to the users.

The current setting also made it easy for us to make changes outside of the terraform, which is bad.  This incoming change also helps address that a little bit by making the user think twice about an edit in the AWS console

This will need to be implemented as a user configurable setting as part of implementing autoscaling.