### PR TITLE
Add privileged bastion option

### DIFF
--- a/gke/main.tf
+++ b/gke/main.tf
@@ -42,6 +42,7 @@ module "kube_private_cluster" {
   allowed_external_cidr_blocks   = var.allowed_cidr_blocks
   enable_nat                     = var.enable_nat
   enable_bastion                 = var.enable_bastion
+  privileged_bastion             = var.privileged_bastion
   enable_istio                   = var.enable_istio
   enable_intranode_communication = var.enable_intranode_communication
   enable_dashboard               = var.enable_dashboard

--- a/gke/private_kubernetes/extra-vms.tf
+++ b/gke/private_kubernetes/extra-vms.tf
@@ -54,7 +54,7 @@ resource "google_compute_instance" "bastion" {
 
   metadata_startup_script = join("\n", [
     "curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.14.10/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/bin/",
-    "echo \"KUBECONFIG=/etc/kube.config gcloud container clusters get-credentials --internal-ip --region ${var.location} ${var.unique_name}-k8s-cluster && ( [ -e /home/ubuntu/.config ] && sudo chown -R ubuntu /home/ubuntu/.config ) && sudo chmod 0644 /etc/kube.config \" > update-kubeconfig && chmod +x update-kubeconfig && sudo mv ./update-kubeconfig /usr/bin/update-kubeconfig && update-kubeconfig",
+    "echo \"gcloud container clusters get-credentials --internal-ip --region ${var.location} ${var.unique_name}-k8s-cluster\" > update-kubeconfig && chmod +x update-kubeconfig && sudo mv ./update-kubeconfig /usr/bin/update-kubeconfig && update-kubeconfig",
     "curl -LO https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv3.5.4/kustomize_v3.5.4_linux_amd64.tar.gz && tar xzf ./kustomize_v3.5.4_linux_amd64.tar.gz && sudo mv ./kustomize /usr/bin/",
     "curl -LO https://github.com/replicatedhq/kots/releases/download/v1.24.1/kots_linux_amd64.tar.gz && tar xzf kots_linux_amd64.tar.gz && sudo mv ./kots /usr/bin/kubectl-kots",
     "curl -LO https://github.com/replicatedhq/troubleshoot/releases/download/v0.9.51/preflight_linux_amd64.tar.gz && tar xzf preflight_linux_amd64.tar.gz && sudo mv ./preflight /usr/bin/kubectl-preflight"

--- a/gke/private_kubernetes/extra-vms.tf
+++ b/gke/private_kubernetes/extra-vms.tf
@@ -5,6 +5,21 @@ resource "google_service_account" "k8s_bastion_service_account" {
   description  = "${var.unique_name} service account for CircleCI Server bastion host"
 }
 
+resource "google_project_iam_member" "k8s_bastion_container_admin" {
+  count      = var.privileged_bastion ? 1 : 0
+  depends_on = [google_service_account.k8s_bastion_service_account]
+  role       = "roles/container.admin"
+  member     = "serviceAccount:${google_service_account.k8s_bastion_service_account.email}"
+}
+
+resource "google_project_iam_member" "k8s_bastion_compute_admin" {
+  count      = var.privileged_bastion ? 1 : 0
+  depends_on = [google_service_account.k8s_bastion_service_account]
+  role       = "roles/compute.admin"
+  member     = "serviceAccount:${google_service_account.k8s_bastion_service_account.email}"
+}
+
+
 resource "google_compute_instance" "bastion" {
   count                     = var.enable_bastion ? 1 : 0
   name                      = "${var.unique_name}-bastion"

--- a/gke/private_kubernetes/variables.tf
+++ b/gke/private_kubernetes/variables.tf
@@ -121,3 +121,7 @@ variable "subnet_uri" {
 variable "private_endpoint" {
   type = bool
 }
+
+variable "privileged_bastion" {
+  type = bool
+}

--- a/gke/variables.tf
+++ b/gke/variables.tf
@@ -74,6 +74,12 @@ variable "enable_bastion" {
   description = "Include a bastion/jump server in deployment. You can restrict the range of IPs that can connect to the bastion using `allowed_cidr_blocks`"
 }
 
+variable "privileged_bastion" {
+  type        = bool
+  default     = false
+  description = "Grants container and compute admin access to the bastion Service Account. Set only to true if you understand the security implications of doing this"
+}
+
 variable "enable_istio" {
   type        = bool
   default     = false


### PR DESCRIPTION
This adds an option to have a privileged bastion host service account as we need it for our CI pipeline. PRs updating our `terraform.tfvars` in our assets repos are to follow.