### PR TITLE
[SERVER-91]use Regular GKE channel, update Google provider

### DIFF
--- a/gke/private_kubernetes/main.tf
+++ b/gke/private_kubernetes/main.tf
@@ -99,8 +99,8 @@ resource "google_project_iam_member" "k8s_memeber_blob_signer" {
 
 ### GKE VERSION ###
 data "google_container_engine_versions" "gke" {
-  provider       = google
-  location       = var.location
+  provider = google
+  location = var.location
 }
 
 ### NODE POOL ###

--- a/gke/private_kubernetes/main.tf
+++ b/gke/private_kubernetes/main.tf
@@ -99,9 +99,8 @@ resource "google_project_iam_member" "k8s_memeber_blob_signer" {
 
 ### GKE VERSION ###
 data "google_container_engine_versions" "gke" {
-  provider       = google-beta
+  provider       = google
   location       = var.location
-  version_prefix = "1.16."
 }
 
 ### NODE POOL ###
@@ -110,7 +109,7 @@ resource "google_container_node_pool" "node_pool" {
   location = var.location
   cluster  = google_container_cluster.circleci_cluster.name
 
-  version = data.google_container_engine_versions.gke.release_channel_default_version["STABLE"]
+  version = data.google_container_engine_versions.gke.release_channel_default_version["REGULAR"]
 
   autoscaling {
     min_node_count = var.node_min
@@ -146,7 +145,7 @@ resource "google_container_cluster" "circleci_cluster" {
   location    = var.location
   provider    = google-beta
 
-  min_master_version = data.google_container_engine_versions.gke.release_channel_default_version["STABLE"]
+  min_master_version = data.google_container_engine_versions.gke.release_channel_default_version["REGULAR"]
 
   network = var.network_uri
   # subnetwork               = var.subnet_uri
@@ -176,19 +175,6 @@ resource "google_container_cluster" "circleci_cluster" {
     }
   }
 
-  # cluster_autoscaling {
-  #   enabled = false
-  #   resource_limits {
-  #     resource_type = "cpu"
-  #     maximum = var.node_pool_cpu_max
-  #     minimum = 1
-  #   }
-  #   resource_limits {
-  #     resource_type = "memory"
-  #     maximum = var.node_pool_ram_max
-  #     minimum = 4
-  #   }
-  # }
   network_policy {
     enabled  = true
     provider = "CALICO"

--- a/gke/terraform.tf
+++ b/gke/terraform.tf
@@ -1,8 +1,8 @@
 # Backend configuration. Can't take variables.
 terraform {
   required_providers {
-    google      = "~> 3.42.0"
-    google-beta = "~> 3.42.0"
+    google      = "~> 3.51.0"
+    google-beta = "~> 3.51.0"
   }
 }
 


### PR DESCRIPTION
Easy stuff first:
- Removed commented out code block
- updated the Providers to the most recent version
- removed `version_prefix` because it is not doing anything when we specify a version by the channel

Less easy stuff:
- EKS is on k8s version 1.18.  1.18 is not yet available in all regions for GKE, so we cannot use it.
- It seems to be preferred to subscribe to a channel instead of specifying a version.  Read more about it [here](https://cloud.google.com/kubernetes-engine/docs/concepts/release-channels), a notable point is all channels are considered safe for GA.  Updating to the Regular channel will get us to k8s version 1.17 today.  This is closer what runs on EKS.  Moving forward we will have to expect there will be discrepancies between the K8s versions on each provider.

Tested by deploying a cluster, Reality Check passed