### PR TITLE
Add Nomad mTLS

### DIFF
--- a/eks/nomad/main.tf
+++ b/eks/nomad/main.tf
@@ -12,6 +12,11 @@ resource "aws_key_pair" "ssh_key" {
   }
 }
 
+module "nomad_tls" {
+  source   = "../../shared/modules/tls"
+  basename = var.basename
+}
+
 module "asg" {
   source  = "terraform-aws-modules/autoscaling/aws"
   version = "~> 3.0"
@@ -40,8 +45,11 @@ module "asg" {
   user_data_base64 = base64encode(templatefile(
     "${path.module}/../../shared/nomad-scripts/nomad-startup.sh.tpl",
     {
-      basename       = var.basename
-      cloud_provider = "AWS"
+      basename        = var.basename
+      cloud_provider  = "AWS"
+      client_tls_cert = module.nomad_tls.nomad_client_cert
+      client_tls_key  = module.nomad_tls.nomad_client_key
+      tls_ca          = module.nomad_tls.nomad_tls_ca
     }
   ))
 
@@ -49,9 +57,9 @@ module "asg" {
   asg_name                  = "${var.basename}-circleci-nomad_asg"
   vpc_zone_identifier       = var.vpc_zone_identifier
   health_check_type         = "EC2"
-  min_size                  = "${var.nomad_count}"
-  max_size                  = "${var.nomad_count}"
-  desired_capacity          = "${var.nomad_count}"
+  min_size                  = var.nomad_count
+  max_size                  = var.nomad_count
+  desired_capacity          = var.nomad_count
   wait_for_capacity_timeout = 0 # skip all Capacity Waiting behavior
 
   tags = [
@@ -124,4 +132,17 @@ resource "aws_security_group" "ssh_sg" {
     protocol    = "-1"
     cidr_blocks = ["0.0.0.0/0"]
   }
+}
+
+# OUTPUTS
+output "nomad_server_cert" {
+  value = module.nomad_tls.nomad_server_cert
+}
+
+output "nomad_server_key" {
+  value = module.nomad_tls.nomad_server_key
+}
+
+output "nomad_tls_ca" {
+  value = module.nomad_tls.nomad_tls_ca
 }

--- a/eks/outputs.tf
+++ b/eks/outputs.tf
@@ -19,3 +19,15 @@ output "vm_service_security_group" {
   value       = aws_security_group.eks_nomad_sg[0].id
   description = "Security group to be used when creating VMs"
 }
+
+output "nomad_server_cert" {
+  value = module.nomad.nomad_server_cert
+}
+
+output "nomad_server_key" {
+  value = module.nomad.nomad_server_key
+}
+
+output "nomad_tls_ca" {
+  value = module.nomad.nomad_tls_ca
+}

--- a/gke/main.tf
+++ b/gke/main.tf
@@ -80,3 +80,15 @@ output "cluster" {
 output "bastion" {
   value = module.kube_private_cluster.bastion > 0 ? module.kube_private_cluster.bastion_name : "Not created."
 }
+
+output "nomad_server_cert" {
+  value = module.nomad.nomad_server_cert
+}
+
+output "nomad_server_key" {
+  value = module.nomad.nomad_server_key
+}
+
+output "nomad_tls_ca" {
+  value = module.nomad.nomad_tls_ca
+}

--- a/gke/nomad/variables.tf
+++ b/gke/nomad/variables.tf
@@ -48,3 +48,4 @@ variable "network_name" {
   type        = string
   description = "Name of the GCP network to attach to nomad"
 }
+

--- a/shared/modules/tls/outputs.tf
+++ b/shared/modules/tls/outputs.tf
@@ -1,0 +1,19 @@
+output "nomad_server_cert" {
+  value = tls_locally_signed_cert.nomad_server.cert_pem
+}
+
+output "nomad_server_key" {
+  value = tls_private_key.nomad_server.private_key_pem
+}
+
+output "nomad_client_cert" {
+  value = tls_locally_signed_cert.nomad_client.cert_pem
+}
+
+output "nomad_client_key" {
+  value = tls_private_key.nomad_client.private_key_pem
+}
+
+output "nomad_tls_ca" {
+  value = tls_self_signed_cert.nomad_ca.cert_pem
+}

--- a/shared/modules/tls/tls.tf
+++ b/shared/modules/tls/tls.tf
@@ -1,0 +1,123 @@
+# This creates self-signed certs to encrypt the traffic between Nomad server and clients
+terraform {
+  required_providers {
+    tls = {
+      source  = "hashicorp/tls"
+      version = "~> 2.2"
+    }
+  }
+}
+
+
+locals {
+  cert_validity_period = 876600 # 100 years, basically doesn't expire
+}
+
+resource "tls_private_key" "nomad_ca" {
+  algorithm = "RSA"
+}
+
+resource "tls_self_signed_cert" "nomad_ca" {
+  key_algorithm   = tls_private_key.nomad_ca.algorithm
+  private_key_pem = tls_private_key.nomad_ca.private_key_pem
+
+  subject {
+    common_name         = "Nomad ${var.basename} CA"
+    organization        = "CircleCI"
+    organizational_unit = "Server"
+    street_address      = ["201 Spear St", "#1200"]
+    locality            = "San Francisco"
+    province            = "CA"
+    country             = "US"
+    postal_code         = "94105"
+  }
+
+  validity_period_hours = local.cert_validity_period
+
+  allowed_uses = [
+    "cert_signing",
+    "crl_signing",
+  ]
+
+  is_ca_certificate = true
+}
+
+resource "tls_private_key" "nomad_client" {
+  algorithm = "RSA"
+}
+
+resource "tls_cert_request" "nomad_client" {
+  key_algorithm   = tls_private_key.nomad_client.algorithm
+  private_key_pem = tls_private_key.nomad_client.private_key_pem
+
+  subject {
+    common_name  = "nomad.${var.basename}.circleci.internal"
+    organization = "nomad:client"
+  }
+
+  dns_names = [
+    "client.global.nomad",
+    "localhost",
+  ]
+
+  ip_addresses = [
+    "127.0.0.1",
+  ]
+}
+
+resource "tls_locally_signed_cert" "nomad_client" {
+  cert_request_pem   = tls_cert_request.nomad_client.cert_request_pem
+  ca_key_algorithm   = tls_private_key.nomad_ca.algorithm
+  ca_private_key_pem = tls_private_key.nomad_ca.private_key_pem
+  ca_cert_pem        = tls_self_signed_cert.nomad_ca.cert_pem
+
+  validity_period_hours = local.cert_validity_period
+
+  allowed_uses = [
+    "client_auth",
+    "digital_signature",
+    "key_agreement",
+    "key_encipherment",
+    "server_auth",
+  ]
+}
+
+resource "tls_private_key" "nomad_server" {
+  algorithm = "RSA"
+}
+
+resource "tls_cert_request" "nomad_server" {
+  key_algorithm   = tls_private_key.nomad_server.algorithm
+  private_key_pem = tls_private_key.nomad_server.private_key_pem
+
+  subject {
+    common_name  = "nomad.${var.basename}.circleci.internal"
+    organization = "nomad:client"
+  }
+
+  dns_names = [
+    "server.global.nomad",
+    "localhost",
+  ]
+
+  ip_addresses = [
+    "127.0.0.1",
+  ]
+}
+
+resource "tls_locally_signed_cert" "nomad_server" {
+  cert_request_pem   = tls_cert_request.nomad_server.cert_request_pem
+  ca_key_algorithm   = tls_private_key.nomad_ca.algorithm
+  ca_private_key_pem = tls_private_key.nomad_ca.private_key_pem
+  ca_cert_pem        = tls_self_signed_cert.nomad_ca.cert_pem
+
+  validity_period_hours = local.cert_validity_period
+
+  allowed_uses = [
+    "client_auth",
+    "digital_signature",
+    "key_agreement",
+    "key_encipherment",
+    "server_auth",
+  ]
+}

--- a/shared/modules/tls/variables.tf
+++ b/shared/modules/tls/variables.tf
@@ -1,0 +1,4 @@
+variable "basename" {
+  type        = string
+  description = "Name of deployment to be used as a base for naming resources."
+}

--- a/shared/nomad-scripts/nomad-startup.sh.tpl
+++ b/shared/nomad-scripts/nomad-startup.sh.tpl
@@ -64,6 +64,20 @@ unzip nomad.zip
 mv nomad /usr/bin
 
 echo "--------------------------------------"
+echo "       Installling TLS certs"
+echo "--------------------------------------"
+mkdir -p /etc/ssl/nomad
+cat <<EOT > /etc/ssl/nomad/cert.pem
+${client_tls_cert}
+EOT
+cat <<EOT > /etc/ssl/nomad/key.pem
+${client_tls_key}
+EOT
+cat <<EOT > /etc/ssl/nomad/ca.pem
+${tls_ca}
+EOT
+
+echo "--------------------------------------"
 echo "      Creating config.hcl"
 echo "--------------------------------------"
 
@@ -87,6 +101,18 @@ client {
     node_class = "linux-64bit"
     options = {"driver.raw_exec.enable" = "1"}
 }
+tls {
+        http = false
+        rpc  = true
+
+        # This verifies the CN ([role].[region].nomad) in the certificate,
+        # not the hostname or DNS name of the of the remote party.
+        # https://learn.hashicorp.com/tutorials/nomad/security-enable-tls?in=nomad/transport-security#node-certificates
+        verify_server_hostname = true
+        ca_file   = "/etc/ssl/nomad/ca.pem"
+        cert_file = "/etc/ssl/nomad/cert.pem"
+        key_file  = "/etc/ssl/nomad/key.pem"
+      }
 EOT
 
 echo "--------------------------------------"


### PR DESCRIPTION
This adds mutual TLS encryption for Nomad server and clients. It generates a CA and
key/cert pairs. While the certs can be injected into the client via the
startup script, the certs for the server have to be copied into kots
config to get them into the cluster.
