### PR TITLE
Secure Nomad clients via iptable rules

### DIFF
--- a/gke/nomad/nomad.tf
+++ b/gke/nomad/nomad.tf
@@ -97,6 +97,19 @@ resource "google_compute_firewall" "nomad_ssh" {
   network       = var.network_name
 }
 
+resource "google_compute_firewall" "nomad_job_ssh" {
+  name        = "${local.basename}-nomad-ssh"
+  description = "${local.basename} firewall rule for CircleCI Server Nomand component to allow SSH access to jobs"
+
+  allow {
+    protocol = "tcp"
+    ports    = ["64535-65535"]
+  }
+  source_ranges = var.ssh_allowed_cidr_blocks
+  target_tags   = ["nomad"]
+  network       = var.network_name
+}
+
 resource "google_compute_instance_group_manager" "nomad_manager" {
   depends_on         = [google_compute_instance_template.nomad_template]
   name               = "${local.basename}-nomad-manager"

--- a/shared/nomad-scripts/nomad-startup.sh.tpl
+++ b/shared/nomad-scripts/nomad-startup.sh.tpl
@@ -187,3 +187,14 @@ echo "--------------------------------------"
 echo "  Start Docker Garbage Collection"
 echo "--------------------------------------"
 /usr/local/sbin/start-units.sh
+
+echo "--------------------------------------"
+echo "  Securing Docker network interfaces"
+echo "--------------------------------------"
+docker_chain="DOCKER-USER"
+/sbin/iptables --wait --insert $docker_chain 1 -i br+ --destination 169.254.169.254/32 -p tcp --dport 53 --jump RETURN # Allow DNS queries
+/sbin/iptables --wait --insert $docker_chain 2 -i br+ --destination 169.254.169.254/32 -p udp --dport 53 --jump RETURN # Allow DNS queries
+/sbin/iptables --wait --insert $docker_chain 3 -i docker+ --destination 169.254.0.0/16 --jump DROP
+/sbin/iptables --wait --insert $docker_chain 4 -i br-+ --destination 169.254.0.0/16 --jump DROP
+/sbin/iptables --wait --insert $docker_chain 5 -i docker+ --destination "10.0.0.0/8" --jump DROP
+/sbin/iptables --wait --insert $docker_chain 6 -i br+ --destination "10.0.0.0/8" --jump DROP


### PR DESCRIPTION
This adds iptable rules to Nomad clients preventing all docker jobs from
talking to the meta-data service or any internal IPs on the network. I
copied the assumption we make in the GKE k8s module that the internal
network will use a 10.0.0.0/8 block (or part thereof) for the internal
IPs.

I also added an additional firewall rule to allow the rerun-with-ssh
functionality for GKE clusters.

To test the functionality, I ran a pipeline that installed curl via apk
(ensuring that normal network traffic was still functional) and then
tried to curl meta-data from `169.254.169.254` which I expected to time
out, which was exactly what happened.
