### PR TITLE
Revert blocking zeroconf IPs

### DIFF
--- a/shared/nomad-scripts/nomad-startup.sh.tpl
+++ b/shared/nomad-scripts/nomad-startup.sh.tpl
@@ -218,9 +218,5 @@ echo "--------------------------------------"
 echo "  Securing Docker network interfaces"
 echo "--------------------------------------"
 docker_chain="DOCKER-USER"
-/sbin/iptables --wait --insert $docker_chain 1 -i br+ --destination 169.254.169.254/32 -p tcp --dport 53 --jump RETURN # Allow DNS queries
-/sbin/iptables --wait --insert $docker_chain 2 -i br+ --destination 169.254.169.254/32 -p udp --dport 53 --jump RETURN # Allow DNS queries
-/sbin/iptables --wait --insert $docker_chain 3 -i docker+ --destination 169.254.0.0/16 --jump DROP
-/sbin/iptables --wait --insert $docker_chain 4 -i br-+ --destination 169.254.0.0/16 --jump DROP
 /sbin/iptables --wait --insert $docker_chain 5 -i docker+ --destination "10.0.0.0/8" --jump DROP
 /sbin/iptables --wait --insert $docker_chain 6 -i br+ --destination "10.0.0.0/8" --jump DROP


### PR DESCRIPTION
Pipeline tests have revealed that blocking the zeroconf IPs has negative side-effects. These rules apparently need to be more sophisticated than that.