### PR TITLE
firewall names compete when bastion is enabled

### DIFF
--- a/gke/nomad/nomad.tf
+++ b/gke/nomad/nomad.tf
@@ -105,7 +105,7 @@ resource "google_compute_firewall" "nomad_ssh" {
 }
 
 resource "google_compute_firewall" "nomad_job_ssh" {
-  name        = "${local.basename}-nomad-ssh"
+  name        = "${local.basename}-nomad-job-ssh"
   description = "${local.basename} firewall rule for CircleCI Server Nomand component to allow SSH access to jobs"
 
   allow {


### PR DESCRIPTION
**Problem:**
When the bastion is enabled the firewall rule [immediately above](https://github.com/CircleCI-Public/server-terraform/blob/1a003422028c5a56b982341e546b4228327ced43/gke/nomad/nomad.tf#L93-L96) is also created and it has the same name.  Terraform returns an error stating the conflict.

**Solution:**
rename one of them
