### PR TITLE
[SERVER-91] update recomended kubectl version in the documentation

### DIFF
--- a/eks/README.md
+++ b/eks/README.md
@@ -10,7 +10,7 @@ following CLIs installed:
 
 
 * [terraform] (tested with 0.14.2)
-* [kubectl] (tested with 1.14.6)
+* [kubectl] (tested with 1.20.0
 * [awscli] (tested with 1.16.261)
 * [server-keysets]
 

--- a/gke/README.md
+++ b/gke/README.md
@@ -9,7 +9,7 @@ To deploy the infrastructure and application you will need to have the
 following CLIs installed:
 
 * [terraform] (tested with 0.14.2)
-* [kubectl] (tested with 1.14.6)
+* [kubectl] (tested with 1.20.0)
 * [gcloud] (tested with 301.0.0)
 * [server-keysets]
   (Actual installation is unnecessary; the Docker image will be pulled


### PR DESCRIPTION
Update documentation to match the new recommended kubectl version.

this documentation update was missed in the last PR.