### PR TITLE
Tighten firewall for VMs in GKE

### DIFF
--- a/gke/main.tf
+++ b/gke/main.tf
@@ -47,6 +47,7 @@ module "kube_private_cluster" {
   enable_intranode_communication = var.enable_intranode_communication
   enable_dashboard               = var.enable_dashboard
   private_endpoint               = var.private_k8s_endpoint
+  private_vms                    = var.private_vms
 
   network_uri = google_compute_network.circleci_net.self_link
   subnet_uri  = data.google_compute_subnetwork.circleci_net_subnet_data.self_link

--- a/gke/private_kubernetes/firewalls.tf
+++ b/gke/private_kubernetes/firewalls.tf
@@ -46,6 +46,7 @@ resource "google_compute_firewall" "allowed_external_cidr_blocks" {
 }
 
 resource "google_compute_firewall" "allow_vm_machine_ports" {
+  count       = var.private_vms ? 0 : 1
   name        = "allow-vm-machine-ports-${var.unique_name}"
   description = "${var.unique_name} firewall rule for CircleCI Server cluster component"
   network     = var.network_uri
@@ -56,6 +57,8 @@ resource "google_compute_firewall" "allow_vm_machine_ports" {
   }
 
   target_tags = ["docker-machine"]
+
+  source_ranges = var.allowed_external_cidr_blocks
 }
 
 resource "google_compute_firewall" "allow_bastion" {

--- a/gke/private_kubernetes/variables.tf
+++ b/gke/private_kubernetes/variables.tf
@@ -122,6 +122,10 @@ variable "private_endpoint" {
   type = bool
 }
 
+variable "private_vms" {
+  type = bool
+}
+
 variable "privileged_bastion" {
   type = bool
 }

--- a/gke/terraform.tfvars.template
+++ b/gke/terraform.tfvars.template
@@ -16,7 +16,8 @@ enable_bastion                 = true
 enable_istio                   = false
 enable_intranode_communication = false
 enable_dashboard               = false
-private_k8s_endpoint               = true
+private_k8s_endpoint           = true
+private_vms                    = true
 
 # The CIDR ranges that are allowed to access those components of your
 # installation that should be accessible via the public internet. By default

--- a/gke/variables.tf
+++ b/gke/variables.tf
@@ -104,10 +104,17 @@ variable "private_k8s_endpoint" {
   description = "By default, the Kubernetes endpoint is only accessible via the bastion host. Set to false if you want access via the public internet. You can use IP whitelisting using `allowed_cidr_blocks` to tighten access for both cases."
 }
 
+variable "private_vms" {
+  type        = bool
+  default     = true
+  description = "By default, the VMs spun up for remote docker and machine executioners are only accessible via the bastion host. Set to false if you want access via the public internet. You can use IP whitelisting using `allowed_cidr_blocks` to tighten access for both cases."
+}
+
+
 variable "allowed_cidr_blocks" {
   type        = list(string)
   default     = []
-  description = "This configures the allowable source IP blocks, depending on your configuration to your bastion host and/or Kubernetes cluster and/or Nomad clients"
+  description = "This configures the allowable source IP blocks, depending on your configuration to your bastion host and/or Kubernetes cluster and/or Nomad clients and/or VMs"
 }
 
 variable "nomad_count" {

--- a/gke/variables.tf
+++ b/gke/variables.tf
@@ -107,7 +107,7 @@ variable "private_k8s_endpoint" {
 variable "private_vms" {
   type        = bool
   default     = true
-  description = "By default, the VMs spun up for remote docker and machine executioners are only accessible via the bastion host. Set to false if you want access via the public internet. You can use IP whitelisting using `allowed_cidr_blocks` to tighten access for both cases."
+  description = "By default, the VMs for the remote docker and machine executors are only accessible via the bastion host. Set to false if you want access via the public internet, in which case you will need to whitelist IPs using `allowed_cidr_blocks`"
 }
 
 


### PR DESCRIPTION
VMs spun up by `vm-service` were open on several ports to
TCP traffic from the entire internet. This commit tightens access as
follows:
* Only allow access via bastion host by default. Access via the public
  internet can be enabled via a variable
* If access via internet is enabled, restrict access to
  `allowed_external_cidr_blocks`

Work to accomplish same in EKS is to follow
