### PR TITLE
Hotfix - fix external VMs

### DIFF
--- a/gke/private_kubernetes/firewalls.tf
+++ b/gke/private_kubernetes/firewalls.tf
@@ -46,7 +46,6 @@ resource "google_compute_firewall" "allowed_external_cidr_blocks" {
 }
 
 resource "google_compute_firewall" "allow_vm_machine_ports" {
-  count       = var.private_vms ? 0 : 1
   name        = "allow-vm-machine-ports-${var.unique_name}"
   description = "${var.unique_name} firewall rule for CircleCI Server cluster component"
   network     = var.network_uri
@@ -58,7 +57,7 @@ resource "google_compute_firewall" "allow_vm_machine_ports" {
 
   target_tags = ["docker-machine"]
 
-  source_ranges = var.allowed_external_cidr_blocks
+  source_ranges = ["0.0.0.0/0"]
 }
 
 resource "google_compute_firewall" "allow_bastion" {


### PR DESCRIPTION
As some communication between nomad clients, the cluster, and the external VMs is conducted via the public internet, we need to reinstate this firewall rule for all configurations for now. However, we hope to get this fixed on the product level, hence the variables introduced in the original PR remain in place for now.