### PR TITLE
Use index to reference nomad_tls module

### DIFF
--- a/gke/nomad/main.tf
+++ b/gke/nomad/main.tf
@@ -59,9 +59,9 @@ resource "google_compute_instance_template" "nomad_template" {
     {
       basename        = local.basename
       cloud_provider  = "GCP"
-      client_tls_cert = module.nomad_tls ? module.nomad_tls.nomad_client_cert : ""
-      client_tls_key  = module.nomad_tls ? module.nomad_tls.nomad_client_key : ""
-      tls_ca          = module.nomad_tls ? module.nomad_tls.nomad_tls_ca : ""
+      client_tls_cert = var.enable_mtls ? module.nomad_tls[0].nomad_client_cert : ""
+      client_tls_key  = var.enable_mtls ? module.nomad_tls[0].nomad_client_key : ""
+      tls_ca          = var.enable_mtls ? module.nomad_tls[0].nomad_tls_ca : ""
     }
   )
 

--- a/gke/nomad/output.tf
+++ b/gke/nomad/output.tf
@@ -1,11 +1,11 @@
 output "nomad_server_cert" {
-  value = module.nomad_tls ? module.nomad_tls.nomad_server_cert : ""
+  value = length(module.nomad_tls) == 1 ? module.nomad_tls[0].nomad_server_cert : ""
 }
 
 output "nomad_server_key" {
-  value = module.nomad_tls ? module.nomad_tls.nomad_server_key : ""
+  value = length(module.nomad_tls) == 1 ? module.nomad_tls[0].nomad_server_key : ""
 }
 
 output "nomad_tls_ca" {
-  value = module.nomad_tls ? module.nomad_tls.nomad_tls_ca : ""
+  value = length(module.nomad_tls) == 1 ? module.nomad_tls[0].nomad_tls_ca : ""
 }


### PR DESCRIPTION
mTLS for nomad on GCP had some errors in how the `nomad_tls` module was being referenced. This ensures we use the index to reference

- Ticket: no ticket
- Change type: 🐛 Bug fix
- Testing Checklist:
  - [ ] Verified installation with mTLS enabled works and passes reality check
  - [ ] Verify installation without mTLS enabled works and passes reality check