### PR TITLE
[No JIRA] fix data type errors in nomad module

### DIFF
--- a/gke/nomad/main.tf
+++ b/gke/nomad/main.tf
@@ -59,9 +59,9 @@ resource "google_compute_instance_template" "nomad_template" {
     {
       basename        = local.basename
       cloud_provider  = "GCP"
-      client_tls_cert = module.nomad_tls ? module.nomad_tls.nomad_client_cert : ""
-      client_tls_key  = module.nomad_tls ? module.nomad_tls.nomad_client_key : ""
-      tls_ca          = module.nomad_tls ? module.nomad_tls.nomad_tls_ca : ""
+      client_tls_cert = var.enable_mtls ? module.nomad_tls[0].nomad_client_cert : ""
+      client_tls_key  = var.enable_mtls ? module.nomad_tls[0].nomad_client_key : ""
+      tls_ca          = var.enable_mtls ? module.nomad_tls[0].nomad_tls_ca : ""
     }
   )
 

--- a/gke/nomad/output.tf
+++ b/gke/nomad/output.tf
@@ -1,11 +1,11 @@
 output "nomad_server_cert" {
-  value = module.nomad_tls ? module.nomad_tls.nomad_server_cert : ""
+  value = var.enable_mtls ? module.nomad_tls[0].nomad_server_cert : ""
 }
 
 output "nomad_server_key" {
-  value = module.nomad_tls ? module.nomad_tls.nomad_server_key : ""
+  value = var.enable_mtls ? module.nomad_tls[0].nomad_server_key : ""
 }
 
 output "nomad_tls_ca" {
-  value = module.nomad_tls ? module.nomad_tls.nomad_tls_ca : ""
+  value = var.enable_mtls ? module.nomad_tls[0].nomad_tls_ca : ""
 }


### PR DESCRIPTION
If you try to create a GKE cluster, currently this will fail for 2 reasons: 
- in `module.nomad_tls ? module.nomad_tls.nomad_server_key : ""`, module.nomad_tls does not evaluate to a boolean. To fix replace `module.nomad_tls` with `var.enable_mtls`
- the nomad_tls module return its attributes as a list so attributes need to be referenced with an index. eg: `module.nomad_tls[0].nomad_server_cert`