### PR TITLE
clarify desired_capacity must be changed in the console

### DIFF
--- a/eks/terraform.tfvars.template
+++ b/eks/terraform.tfvars.template
@@ -28,4 +28,4 @@ nomad_ssh_key = null  # Set to valid SSH public key to enable SSH access to noma
 # instance_type      = "m4.xlarge"
 # max_capacity       = 5
 # min_capacity       = 4
-# desired_capacity   = 4
+# desired_capacity   = 4   # Changes to this value are not respected by terraform and must be done manually through the console per: https://github.com/terraform-aws-modules/terraform-aws-eks/issues/835

--- a/eks/variables.tf
+++ b/eks/variables.tf
@@ -124,7 +124,7 @@ variable "min_capacity" {
 variable "desired_capacity" {
   type        = number
   default     = 4
-  description = "The desired number of worker nodes in the cluster"
+  description = "The desired number of worker nodes in the cluster.  Changes to this value are not respected by terraform per: https://github.com/terraform-aws-modules/terraform-aws-eks/issues/835"
 }
 
 variable "enable_mtls" {


### PR DESCRIPTION
**Problem**:
changing the desired_capacity in terraform after initial creation does nothing

**Explanation**:
-  This is by design from the module used: https://github.com/terraform-aws-modules/terraform-aws-eks/issues/835
- server-terraform does not yet support autoscaling.  Manually scaling needs to be done through the console at this time
- Supporting autoscaling will need to be done with this autoscaler: https://github.com/kubernetes/autoscaler