### PR TITLE
Invert the logic to only load SSL certs when they are non-zero

### DIFF
--- a/shared/nomad-scripts/nomad-startup.sh.tpl
+++ b/shared/nomad-scripts/nomad-startup.sh.tpl
@@ -103,7 +103,7 @@ client {
 }
 EOT
 
-if [ -z $client_tls_cert ];
+if [ -n $client_tls_cert ];
 then cat <<EOT >> /etc/nomad/config.hcl
 tls {
     http = false


### PR DESCRIPTION
We should only be loading the TLS section if the cert is non-zero - the previous content had this logic inverted.