### PR TITLE
[No JIRA] syntax: bash conditional needs brackets so that the tls block is not …

### DIFF
--- a/shared/nomad-scripts/nomad-startup.sh.tpl
+++ b/shared/nomad-scripts/nomad-startup.sh.tpl
@@ -103,7 +103,7 @@ client {
 }
 EOT
 
-if [ -n $client_tls_cert ];
+if [[ -n $client_tls_cert ]];
 then cat <<EOT >> /etc/nomad/config.hcl
 tls {
     http = false


### PR DESCRIPTION
An addition up to the mtls toggle work by @ryanwohara

bash conditional needs brackets so that the tls block is not entered when no tls cert is provided