### PR TITLE
[No JIRA] force_destroy was not configured for gke buckets

### DIFF
--- a/eks/s3.tf
+++ b/eks/s3.tf
@@ -7,6 +7,6 @@ resource "aws_s3_bucket" "data_bucket" {
     Environment   = "circleci"
     circleci      = true
     Name          = "${var.basename}-circleci-data"
-    force_destroy = true
+    force_destroy = var.force_destroy
   }
 }

--- a/gke/main.tf
+++ b/gke/main.tf
@@ -55,6 +55,9 @@ module "kube_private_cluster" {
 
 resource "google_storage_bucket" "data_bucket" {
   name = "${var.basename}-data"
+
+  force_destroy = var.force_destroy
+
   labels = {
     circleci = true
   }

--- a/gke/terraform.tfvars.template
+++ b/gke/terraform.tfvars.template
@@ -2,6 +2,8 @@ basename          = ""        # Prefix added to cluster resources
 project_id        = ""        # Name of the google cloud project
 project_loc       = ""        # Region to create cluster IE us-east1 
 
+force_destroy     = false     # Forces destroy of the S3 data bucket on `terraform destroy`.  Useful as true for development purposes.  Data in bucket will be unrecoverable   
+
 node_spec         = "n1-standard-8"
 node_min          = 1
 node_max          = 9

--- a/gke/variables.tf
+++ b/gke/variables.tf
@@ -9,6 +9,11 @@ variable "project_loc" {
   description = "Valid GKE location."
 }
 
+variable "force_destroy" {
+  type    = bool
+  default = false
+}
+
 variable "basename" {
   type        = string
   description = "Name of deployment to be used as a base for naming resources."


### PR DESCRIPTION
GCP buckets did not have the option to toggle force_destroy

Also an update to the S3 bucket tagging to reflect the state of force_destroy