### PR TITLE
Add bastion host security

### DIFF
--- a/eks/bastion.tf
+++ b/eks/bastion.tf
@@ -1,5 +1,5 @@
 resource "aws_key_pair" "bastion_key" {
-  count      = var.enable_bastion ? 1 : 0
+  count      = var.bastion_key != "" ? 1 : 0
   key_name   = "${var.basename}-circleci-bastion-key"
   public_key = var.bastion_key
   tags = {
@@ -68,6 +68,37 @@ resource "aws_iam_role" "bastion_role" {
   }
 }
 
+resource "aws_iam_policy" "bastion_access" {
+  count       = var.enable_bastion ? 1 : 0
+  name        = "${var.basename}-cci-cluster-bastion_access"
+  path        = "/"
+  description = "IAM policy for access to the EKS bastion host"
+
+  policy = <<-EOF
+    {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Effect": "Allow",
+          "Action": "ec2-instance-connect:SendSSHPublicKey",
+          "Resource": [ "${aws_instance.bastion[0].arn}" ],
+          "Condition": {
+            "StringEquals": {
+              "ec2:osuser": "ubuntu"
+            }
+          }
+        },
+        {
+          "Effect": "Allow",
+          "Action": "ec2:DescribeInstances",
+          "Resource": "*"
+        }
+      ]
+    }
+  EOF
+}
+
+
 resource "aws_iam_policy" "bastion_policy" {
   count       = var.enable_bastion ? 1 : 0
   name        = "${var.basename}-circleci-cluster-bastion_policy"
@@ -84,9 +115,28 @@ resource "aws_iam_policy" "bastion_policy" {
             "eks:ListClusters",
             "eks:DescribeCluster"
           ],
-          "Resource": [
-            "${module.eks-cluster.cluster_arn}"
-          ]
+          "Resource": "${module.eks-cluster.cluster_arn}",
+          "Condition": {
+            "StringEquals": {
+              "aws:ResourceTag/kubernetes-cluster-name": "${local.cluster_name}"
+            }
+          }
+        },
+        {
+          "Effect": "Allow",
+          "Action": "ec2-instance-connect:SendSSHPublicKey",
+          "Resource": "*",
+          "Condition": {
+            "StringEquals": {
+                "ec2:ResourceTag/nomadclient": "true",
+                "ec2:osuser": "ubuntu"
+            }
+          }
+        },
+        {
+          "Effect": "Allow",
+          "Action": "sts:AssumeRole",
+          "Resource": %{if var.additional_bastion_role_arn != ""}["${aws_iam_role.bastion_role[0].arn}", "${var.additional_bastion_role_arn}"]%{else}"${aws_iam_role.bastion_role[0].arn}"%{endif}
         }
       ]
     }
@@ -113,25 +163,70 @@ resource "aws_instance" "bastion" {
   user_data                   = <<-EOF
     #!/bin/bash
     sudo apt update -y
-    sudo apt install -y awscli
-    aws eks update-kubeconfig --name ${module.eks-cluster.cluster_id} --region ${var.aws_region} --kubeconfig /home/ubuntu/.kube/config
+    echo ### INSTALLING PACKAGES ###
+    sudo apt install -y awscli ec2-instance-connect python-pip jq
+    pip install ec2instanceconnectcli
+    echo ### CONFIGURING AWS CREDENTIALS ###
+    mkdir /home/ubuntu/.aws
+    cat <<- EOT > /home/ubuntu/.aws/credentials
+    [instance]
+    role_arn = ${aws_iam_role.bastion_role[0].arn}
+    credential_source = Ec2InstanceMetadata
+    region = ${var.aws_region}
+    EOT
+    chown -R ubuntu /home/ubuntu/.aws
+    mkdir ~/.aws
+    cat <<- EOT > ~/.aws/credentials
+      [default]
+      role_arn = ${aws_iam_role.bastion_role[0].arn}
+      credential_source = Ec2InstanceMetadata
+      region = ${var.aws_region}
+    EOT
+    echo ### CONFIGURING UBUNTU .bashrc ###
+    cat <<- EOT > /home/ubuntu/.bashrc
+      export AWS_PROFILE=instance
+      alias k=kubectl
+      source <(kubectl completion bash)
+      update-kubeconfig
+    EOT
+    chown ubuntu /home/ubuntu/.bashrc
 
-    # Kubernetes Tooling
+    echo ### INSTALLING ADDITIONAL K8s SOFTWARE ###
     curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.20.0/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/bin/
     curl -LO https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv3.8.8/kustomize_v3.8.8_linux_amd64.tar.gz && tar xzf ./kustomize_v3.8.8_linux_amd64.tar.gz && sudo mv ./kustomize /usr/bin/
     curl -LO https://github.com/replicatedhq/kots/releases/download/v1.25.2/kots_linux_amd64.tar.gz && tar xzf kots_linux_amd64.tar.gz && sudo mv ./kots /usr/bin/kubectl-kots
     curl -LO https://github.com/replicatedhq/troubleshoot/releases/download/v0.9.54/preflight_linux_amd64.tar.gz && tar xzf preflight_linux_amd64.tar.gz && sudo mv ./preflight /usr/bin/kubectl-preflight
+
+    echo ### CONFIGURING EKS AUTH ###
+    cat <<- EOT > ~/aws-auth-cm.yaml
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: aws-auth
+        namespace: kube-system
+      data:
+        mapRoles: |
+          - rolearn: ${aws_iam_role.bastion_role[0].arn}
+            username: cluster-admin
+            groups:
+              - system:masters
+    EOT
+    aws eks update-kubeconfig --name ${local.cluster_name} --region ${var.aws_region} --role-arn ${var.additional_bastion_role_arn}
+    kubectl apply -f ~/aws-auth-cm.yaml --kubeconfig=/root/.kube/config
+    echo aws eks update-kubeconfig --name ${local.cluster_name} --region ${var.aws_region} > /usr/bin/update-kubeconfig
+    chmod +x /usr/bin/update-kubeconfig
+    echo ### END OF USER DATA ###
   EOF
 
-  key_name               = aws_key_pair.bastion_key[0.0].key_name
+  key_name               = aws_key_pair.bastion_key != [] ? aws_key_pair.bastion_key[0.0].key_name : null
   vpc_security_group_ids = [module.vpc.default_security_group_id, aws_security_group.bastion_ssh[0.0].id]
   subnet_id              = module.vpc.public_subnets[0]
   iam_instance_profile   = aws_iam_instance_profile.bastion_iam_profile[0].name
 
-  tags = {
+  tags = merge({
     Terraform   = "true"
     circleci    = "true"
     Environment = "circleci"
     Name        = "${var.basename}-circleci-bastion"
-  }
+  }, var.additional_bastion_tags)
 }

--- a/eks/managing_user_access.md
+++ b/eks/managing_user_access.md
@@ -1,11 +1,71 @@
-# Managing Access to your Kubernetes cluster
-The following document assumes you have used the terraform scripts found in this repository to create a Kubernetes cluster for your CircleCI server installation. Below we go through our recommended approach to providing and managing user access.
+# Managing Access to your Kubernetes cluster The following document assumes you
+have used the terraform scripts found in this repository to create a Kubernetes
+cluster for your CircleCI server installation. Furthermore, it is assumed that
+you have used the default values which will set up a kubernetes cluster with a
+bastion host and no public endpoint. Below we go through our recommended
+approach to providing and managing user access.
 
+## Access to the bastion
 
-## Adding Cluster Administrators
-Cluster admins are first registered via appending their IPs and IAM user details to the appropriate lists in your `terraform.tfvars` file.
+Access to the bastion is granted via EC2 Instance Connect so that you do not
+have to manage and share SSH keys yourself. To allow a user access to the
+bastion, they must have the `ec2-instance-connect:SendSSHPublicKey` permission
+for the bastion. For your convenience, an IAM policy is created for you that
+you can assign to users or roles you want to have access to the bastion:
+`<basename>-cci-cluster-bastion_access`. Simply attach it to any user or group
+you want to grant access to your bastion and make sure that their IPs are added
+to the `allowed_cidr_blocks`. Keep in mind that users who already have
+extensive permissions within your AWS account might be able to access the
+bastion without having been granted permission explicitly.
 
-example:
+For a user to connect to the bastion, they can either use the EC2 Instance
+Connect option from the AWS Console in their browser or install the EC2
+Instance Connect CLI with `pip`:
+
+`pip install ec2instanceconnectcli`
+
+To connect to the bastion host, use the following command:
+
+`mssh ubuntu@<bastion host instance ID>`
+
+Keep in mind that the ubuntu user has `sudo` access. If you want to create a
+less-privileged user, you would have to create it on the bastion host and add a
+separate IAM role for this OS user, specifying the bastion host username as
+condition on the IAM policy granting the user the
+`ec2-instance-connect:SendSSHPublicKey` permission for the bastion:
+
+```
+…
+"Condition": {
+    "StringEquals": {
+        "ec2:osuser": "<bastion host username>"
+    }
+}
+…
+```
+
+You can also still use the `ssh` command to connect to the bastion host if you
+push your public ssh key to the instance first:
+```
+aws ec2-instance-connect send-ssh-public-key \
+    --instance-id <bastion host instance ID> \
+    --availability-zone <bastion host region> \
+    --instance-os-user ubuntu \
+    --ssh-public-key file://my_rsa_key.pub
+```
+After runnning this command you can connect to the bastion host with `ssh`
+using your private key and using the ubuntu user for 60 seconds. After 60
+seconds, the key will be removed from the bastion host automatically.
+
+As `mssh` doesn't support the `-L` flag for port-forwarding, you probably want
+to alias the command for pushing your ssh key and use `ssh` for
+port-forwarding.
+
+## Adding Cluster Administrators when using a public endpoint Should you use a
+public endpoint, you can register cluster admins via appending their IPs and
+IAM user details to the appropriate lists in your `terraform.tfvars` file.
+
+Example:
 ```
 allowed_cidr_blocks = ["user_ip/32","user1_ip/32"]
 k8s_administrators = [
@@ -22,18 +82,28 @@ k8s_administrators = [
 }
 ```
 
+If you are using a bastion host, the bastion host's instance role is registered
+as a cluster admin automatically and the list in the `terraform.tfvars` file
+has no effect.
 
-### Updating the Cluster admin list
-If you wish to add/remove admin users from your existing cluster, you only need to update the values in your `terraform.tfvars` and run `terrafrom apply`.
+### Updating the Cluster admin list If you wish to add/remove admin users from
+your existing cluster, you only need to update the values in your
+`terraform.tfvars` and run `terrafrom apply`.
 
-## Adding Users with Limited Resource Access
-You may not wish for each user to have complete access of to all cluster resources. To more finely tune user access we make use of kubernetes' role based access control ([RBAC]).
-In the following example we will create a role which will have limited access to a `develop` namespace and then map it to an IAM user. You will need to be a cluster administrator as detailed above to proceed with the following steps.
+## Adding Users with Limited Resource Access You may not wish for each user to
+have complete access of to all cluster resources. To more finely tune user
+access we make use of kubernetes' role based access control ([RBAC]).  In the
+following example we will create a role which will have limited access to a
+`develop` namespace and then map it to an IAM user. You will need to be
+connected to the bastion host or, should you use a public endpoint, be a
+cluster administrator as detailed above to proceed with the following steps.
 
-First we will need to add the user's ARN to the aws-auth configmap in the kube-system namespace.
+First we will need to add the user's ARN to the aws-auth configmap in the
+kube-system namespace.
 
 1. First we edit the `aws-auth` configmap:
-- Create a local copy of the aws-auth configmap: `kubectl get configmap -n kube-system aws-auth -o yaml > aws-auth.yaml`
+- Create a local copy of the aws-auth configmap:
+  `kubectl get configmap -n kube-system aws-auth -o yaml > aws-auth.yaml`
 
 - Then add the user details under `mapUsers` in the configmap's data:
 ```
@@ -73,7 +143,8 @@ rules:
 `kubectl apply -f read-role.yaml`
 
 
-3. Now we will create a `role-binding` on our user's ARN and the pod-reader role in the cluster to define their access level.
+3. Now we will create a `role-binding` on our user's ARN and the pod-reader
+   role in the cluster to define their access level.
 - add the following to a file called `read-role-binding.yaml`
 ```
 kind: RoleBinding
@@ -94,17 +165,22 @@ roleRef:
 - and then apply the role-binding to your cluster:
 `kubectl apply -f read-role-binding.yaml`
 
-4. Finally, to grant access to the cluster, you will need to whitelist the user's IP address.
-- As with admin users, we will need to add the user's IP to your terrafrom.tfvars and `terraform apply`
+4. Finally, to grant access to the cluster, you will need to whitelist the
+user's IP address.
+- As with admin users, we will need to add the user's IP to your
+  terrafrom.tfvars and `terraform apply`
 
-Now your user will be able to access the cluster but will only be able to view pod resources in the develop namespace.
+Now your user will be able to access the cluster but will only be able to view
+pod resources in the develop namespace.
 
-For more details on managing permissions, you may read Google's [RBAC] documentation.
+For more details on managing permissions, you may read Google's [RBAC]
+documentation.
 
 
-## Providing Access with IAM Groups
-You may not wish to repeat the process above for each user you wish to add. Many users will require the same access levels. We can limit the repitition by assigning users to IAM groups.
-Similary to users, groups may also be mapped to roles to provide access management.
+## Providing Access with IAM Groups You may not wish to repeat the process
+above for each user you wish to add. Many users will require the same access
+levels. We can limit the repitition by assigning users to IAM groups.  Similary
+to users, groups may also be mapped to roles to provide access management.
 
 1. First create an IAM role:
 ```
@@ -146,7 +222,8 @@ aws iam put-group-policy \
 ```
 
 3. Next we create the role and role-binding:
-- create a file called dev-role-binding.yaml with the following. We will be applying these resources to the `develop` namespace as before.
+- create a file called dev-role-binding.yaml with the following. We will be
+  applying these resources to the `develop` namespace as before.
 ```
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1beta1
@@ -197,7 +274,8 @@ roleRef:
 ```
 
 4. Then create the mapping of the IAM role to our k8s dev user
-- Create a local copy of the aws-auth configmap: `kubectl get configmap -n kube-system aws-auth -o yaml > aws-auth.yaml`
+- Create a local copy of the aws-auth configmap:
+  `kubectl get configmap -n kube-system aws-auth -o yaml > aws-auth.yaml`
 
 - Then add the user details under `mapUsers` in the configmap's data:
 ```
@@ -219,9 +297,20 @@ data:
 
 5. Now when you need to give a user dev access you can simply:
 - add them to the dev group you created
-`aws iam add-user-to-group --group-name k8sDev --user-name <username>`
+  `aws iam add-user-to-group --group-name k8sDev --user-name <username>`
 
 - and update the terraform.tfvars with their IP, then run `terraform apply`
+
+## Acessing the Nomad clients
+
+There are two ways how you can access the nomad clients. By default, you can
+connect to the nomad clients using the bastion host using mssh. You connect to
+the bastion host first and on the bastion host, you run the same command again
+`mssh ubuntu@<instance id of the Nomad client>`.
+
+Alternatively, you can provide your own SSH key for the Nomad clients, using
+the `nomad-ssh-key` terraform variable. Keep in mind that this will open port
+22 on the public IP of the Nomad clients.
 
 
 Sources and further reading:

--- a/eks/managing_user_access.md
+++ b/eks/managing_user_access.md
@@ -58,8 +58,18 @@ using your private key and using the ubuntu user for 60 seconds. After 60
 seconds, the key will be removed from the bastion host automatically.
 
 As `mssh` doesn't support the `-L` flag for port-forwarding, you probably want
-to alias the command for pushing your ssh key and use `ssh` for
-port-forwarding.
+to alias the command above for pushing your ssh key and use `ssh` for
+port-forwarding. You will use port-forwarding via the bastion for accessing
+the kots admin console like so:
+```
+ssh -i <path to your rsa key> ubuntu@<bastion host IP> -- -f kubectl kots admin-console -n <your cluster namespace>; \
+ssh -i <path to your rsa key> ubuntu@<bastion host IP> -- -NnL 8800:localhost:8800; \
+ssh -i <path to your rsa key> ubuntu@<bastion host IP> -- killall kubectl-kots
+```
+The first command connects the bastion to kots admin console. The second
+command forwards the port to the admin console to your local machine. As soon
+as you CTRL+C out of this command, the third command will close the connection
+between the bastion and kots admin console.
 
 ## Adding Cluster Administrators when using a public endpoint Should you use a
 public endpoint, you can register cluster admins via appending their IPs and
@@ -309,8 +319,9 @@ the bastion host first and on the bastion host, you run the same command again
 `mssh ubuntu@<instance id of the Nomad client>`.
 
 Alternatively, you can provide your own SSH key for the Nomad clients, using
-the `nomad-ssh-key` terraform variable. Keep in mind that this will open port
-22 on the public IP of the Nomad clients.
+the `nomad-ssh-key` terraform variable. If you don't set the
+`nomad_public_ssh_port` variable to `true`, you will need to copy the private
+key to the bastion host yourself.
 
 
 Sources and further reading:

--- a/eks/nomad.tf
+++ b/eks/nomad.tf
@@ -10,6 +10,7 @@ module "nomad" {
   sg_enabled              = var.sg_enabled
   ssh_allowed_cidr_blocks = var.allowed_cidr_blocks
   ssh_key                 = var.nomad_ssh_key
+  public_ssh_port         = var.nomad_public_ssh_port
   vpc_id                  = module.vpc.vpc_id
   vpc_zone_identifier     = module.vpc.public_subnets
 }

--- a/eks/nomad/main.tf
+++ b/eks/nomad/main.tf
@@ -51,6 +51,7 @@ module "asg" {
       client_tls_cert = var.enable_mtls ? module.nomad_tls[0].nomad_client_cert : ""
       client_tls_key  = var.enable_mtls ? module.nomad_tls[0].nomad_client_key : ""
       tls_ca          = var.enable_mtls ? module.nomad_tls[0].nomad_tls_ca : ""
+      nomad_ssh       = local.ssh_enabled
     }
   ))
 
@@ -77,6 +78,11 @@ module "asg" {
     {
       key                 = "Environment"
       value               = "circleci"
+      propagate_at_launch = true
+    },
+    {
+      key                 = "nomadclient"
+      value               = "true"
       propagate_at_launch = true
     }
   ]

--- a/eks/nomad/variables.tf
+++ b/eks/nomad/variables.tf
@@ -32,14 +32,20 @@ variable "vpc_zone_identifier" {
 
 variable "ssh_allowed_cidr_blocks" {
   type        = list(string)
-  default     = ["0.0.0.0/0"]
-  description = "List of allowed source IP addresses that can access Nomad clients via SSH. Has no effict if `ssh_key` not set."
+  default     = []
+  description = "List of allowed source IP addresses that can access Nomad clients via SSH. Has no effect if `ssh_key` not set."
 }
 
 variable "ssh_key" {
   type        = string
   default     = null
   description = "SSH key to authenticate access to Nomad clients. If not set, SSH is disabled"
+}
+
+variable "public_ssh_port" {
+  type        = bool
+  default     = false
+  description = "Determines whether port 22 is open to the IPs defined by ssh_allowed_cidr_blocks"
 }
 
 variable "enable_mtls" {

--- a/eks/outputs.tf
+++ b/eks/outputs.tf
@@ -31,3 +31,13 @@ output "nomad_server_key" {
 output "nomad_tls_ca" {
   value = module.nomad.nomad_tls_ca
 }
+
+locals {
+  bastion_connect_command = var.bastion_key == "" ? "mssh ubuntu@${aws_instance.bastion[0.0].id}" : "ssh ubuntu@${aws_instance.bastion[0.0].public_ip}"
+}
+
+output "bastion_access_information" {
+  value       = var.enable_bastion ? "To connect to your bastion run '${local.bastion_connect_command}'" : "bastion has been disabled"
+  description = "Bastion host access information"
+}
+

--- a/eks/terraform.tf
+++ b/eks/terraform.tf
@@ -4,7 +4,7 @@ terraform {
       version = "~> 1.11"
     }
     aws = {
-      version = "~> 3.0.0"
+      version = "~> 3.3.0"
     }
   }
 }
@@ -12,4 +12,7 @@ terraform {
 provider "aws" {
   region  = var.aws_region
   profile = var.aws_profile != "" ? var.aws_profile : null
+  assume_role {
+    role_arn = var.additional_bastion_role_arn
+  }
 }

--- a/eks/terraform.tfvars.template
+++ b/eks/terraform.tfvars.template
@@ -33,8 +33,12 @@ nomad_count   = 1
 # Set to valid SSH public key to enable SSH access to nomad clients from the
 # internet or if you don't want to use EC2 Instance connect from the bastion
 # host but a specific key. You'll need to copy that key to the bastion yourself
-# in this case.
-nomad_ssh_key = null
+# in this case. Leave as "ec2InstanceConnect" if you want to use EC2 Instance
+# Connect or set to null to disable SSH access to Nomad clients altogether
+nomad_ssh_key = "ec2InstanceConnect"
+# open port 22 for ssh access from the internet from the IPs whitelisted in
+# allowed_cidr_blocks above
+nomad_public_ssh_port = false
 
 # Cluster node details - uncomment to manage node type and numbers. Below are the default values so if these are fine no need to uncomment
 # instance_type      = "m4.xlarge"

--- a/eks/terraform.tfvars.template
+++ b/eks/terraform.tfvars.template
@@ -2,13 +2,20 @@ basename         = ""        # Prefix added to cluster resources
 aws_region       = ""        # Region to create cluster IE us-east-1
 
 enable_bastion   = true      # Enable a bastion host for the eks cluster
-bastion_key      = ""        # cat the public ssh key to use for the bastion host.
+# If you want to use a self-managed SSH key to access the bastion, add the
+# public key of the key pair here. If you want to have AWS manage this for
+# you by using EC2 Instance connect, leave as is.
+bastion_key = ""
+# The role you use to setup the cluster and is added temporarily to the bastion
+# See README.md for details
+additional_bastion_role_arn = ""
+additional_bastion_tags = {} # any tags you want to add to your bastion host
 
 # The CIDR ranges that are allowed to access the Kubernetes cluster.
 # Developers, this is typically the public IP address of your home/office network
 # IE ["1.2.3.4/32"]
-# The default is ["0.0.0.0/0"], which implements no IP restrictions
-# allowed_cidr_blocks = [""]
+# The default is an empty list, disabling access completely. If you don't want to restrict access at all, you can set "0.0.0.0/0" to allow access from all IPs
+# allowed_cidr_blocks = []
 
 force_destroy    = false    # Forces destroy of the S3 data bucket on `terraform destroy`.  Useful as true for development purposes.  Data in bucket will be unrecoverable   
 
@@ -20,9 +27,14 @@ k8s_administrators  = []    # add any AWS users here who should also have access
 #       userarn  = "<user ARN>"
 #       username = "<username>"
 #   }
+# This only takes effect if you use a public endpoint instead of a bastion host
 
 nomad_count   = 1
-nomad_ssh_key = null  # Set to valid SSH public key to enable SSH access to nomad clients
+# Set to valid SSH public key to enable SSH access to nomad clients from the
+# internet or if you don't want to use EC2 Instance connect from the bastion
+# host but a specific key. You'll need to copy that key to the bastion yourself
+# in this case.
+nomad_ssh_key = null
 
 # Cluster node details - uncomment to manage node type and numbers. Below are the default values so if these are fine no need to uncomment
 # instance_type      = "m4.xlarge"

--- a/eks/variables.tf
+++ b/eks/variables.tf
@@ -21,6 +21,21 @@ variable "enable_bastion" {
   default = true
 }
 
+variable "bastion_key" {
+  default     = ""
+  description = "The bastion is using EC2 Instance Connect by default. Supply a key if you want to manage SSH keys yourself"
+}
+
+variable "additional_bastion_role_arn" {
+  default     = ""
+  description = "This should be set to the role you are using for setting up your cluster"
+}
+
+variable "additional_bastion_tags" {
+  default     = {}
+  description = "Additional tags to add to your bastion host"
+}
+
 variable "k8s_administrators" {
   default = []
 }
@@ -31,10 +46,6 @@ variable "k8s_roles" {
 
 variable "force_destroy" {
   default = false
-}
-
-variable "bastion_key" {
-  default = ""
 }
 
 variable "aws_vpc_cidr_block" {
@@ -50,11 +61,11 @@ variable "aws_vpc_private_cidr_blocks" {
 }
 
 variable "allowed_cidr_blocks" {
-  default = ["0.0.0.0/0"]
+  default = []
 }
 
 variable "allowed_ipv6_cidr_blocks" {
-  default = ["::/0"]
+  default = []
 }
 
 variable "sg_enabled" {

--- a/eks/variables.tf
+++ b/eks/variables.tf
@@ -110,8 +110,14 @@ variable "nomad_count" {
 
 variable "nomad_ssh_key" {
   type        = string
-  default     = null
-  description = "SSH key to authenticate access to Nomad clients. If not set SSH access is disabled"
+  default     = "ec2InstanceConnect"
+  description = "SSH key to authenticate access to Nomad clients. If not set SSH access is disabled. If set to ec2InstanceConnect, Nomad clients will use ec2InstanceConnect"
+}
+
+variable "nomad_public_ssh_port" {
+  type        = bool
+  default     = false
+  description = "Determines whether port 22 on the Nomad clients is open to incoming traffic from the internet, filtered by allowed_cidr_blocks"
 }
 
 variable "instance_type" {

--- a/gke/nomad/main.tf
+++ b/gke/nomad/main.tf
@@ -62,6 +62,7 @@ resource "google_compute_instance_template" "nomad_template" {
       client_tls_cert = var.enable_mtls ? module.nomad_tls[0].nomad_client_cert : ""
       client_tls_key  = var.enable_mtls ? module.nomad_tls[0].nomad_client_key : ""
       tls_ca          = var.enable_mtls ? module.nomad_tls[0].nomad_tls_ca : ""
+      nomad_ssh       = var.ssh_enabled
     }
   )
 

--- a/shared/nomad-scripts/nomad-startup.sh.tpl
+++ b/shared/nomad-scripts/nomad-startup.sh.tpl
@@ -28,6 +28,9 @@ echo "-------------------------------------------"
 echo "     Performing System Updates"
 echo "-------------------------------------------"
 apt-get update && apt-get -y upgrade
+if [ "$CLOUD_PROVIDER" == "AWS" -a ${nomad_ssh} == "true" ]; then
+    apt-get install -y ec2-instance-connect
+fi
 
 echo "--------------------------------------"
 echo "        Installing NTP"


### PR DESCRIPTION
This commit is quite extensive. It aims to ensure that there is no
access to the cluster from the public internet when a bastion host is
used. In addition, there were some usability improvements. Quick
overview on the changes:

- Use only a private endpoint in EKS when a bastion is used
  The main and major change, ensuring that the bastion host is the only
  way to work on the k8s cluster. This necessitates some acrobatics,
  though: As the EKS module cannot configure the cluster itself after it
  has been set up, the user must provide a role that is used to set up the
  cluster. This role is assumed by the bastion host during startup and the
  bastion host then inserts its own instance profile as cluster admin.

- Add some QOL improvements to the bastion: Aliasing `kubectl` with `k`,
  get current EKS kubeconfig automatically when starting a new session, enable
  `kubectl` autocompletion, ensure that AWS CLI is setup to use the instance
  profile, option to add additional tags to the bastion.

- Add option to use EC2 Instance Connect. Similar to use using OSLogin
  in GKE, this commit adds the option to use EC2 Instance Connect and
  does so by default. The main advantage is that AWS will manage SSH
  keys for you and bastion host access can be administered using IAM
  users, roles and permissions. This has also been implemented for SSH
  connections from the bastion host to the Nomad clients.

- Add lots of documentation and improve formatting
