### PR TITLE
Fix Nomad startup script

### DIFF
--- a/shared/nomad-scripts/nomad-startup.sh.tpl
+++ b/shared/nomad-scripts/nomad-startup.sh.tpl
@@ -103,13 +103,12 @@ client {
 }
 EOT
 
-if [[ -n $client_tls_cert ]];
-then cat <<EOT >> /etc/nomad/config.hcl
+if [ "${client_tls_cert}" ]; then
+cat <<EOT >> /etc/nomad/config.hcl
 tls {
-    http = false
+http = false
     rpc  = true
-
-    # This verifies the CN ([role].[region].nomad) in the certificate,
+     # This verifies the CN ([role].[region].nomad) in the certificate,
     # not the hostname or DNS name of the of the remote party.
     # https://learn.hashicorp.com/tutorials/nomad/security-enable-tls?in=nomad/transport-security#node-certificates
     verify_server_hostname = true


### PR DESCRIPTION
The if statement in the Nomad startup script didn't resolve correctly, leading to the Nomad clients not being able to connect to the server correctly