### PR TITLE
Add private Nomad client option

### DIFF
--- a/eks/nomad.tf
+++ b/eks/nomad.tf
@@ -11,5 +11,6 @@ module "nomad" {
   ssh_allowed_cidr_blocks = var.allowed_cidr_blocks
   ssh_key                 = var.nomad_ssh_key
   vpc_id                  = module.vpc.vpc_id
-  vpc_zone_identifier     = module.vpc.public_subnets
+  vpc_zone_identifier     = var.private_nomad_clients ? module.vpc.private_subnets : module.vpc.public_subnets
+  private_clients         = var.private_nomad_clients
 }

--- a/eks/nomad/main.tf
+++ b/eks/nomad/main.tf
@@ -27,9 +27,10 @@ module "asg" {
   # Launch configuration
   lc_name = "${var.basename}-circleci-nomad_lc"
 
-  image_id      = var.ami_id
-  instance_type = var.nomad_instance_type
-  key_name      = local.ssh_enabled ? aws_key_pair.ssh_key[0].id : null
+  image_id                    = var.ami_id
+  instance_type               = var.nomad_instance_type
+  associate_public_ip_address = !var.private_clients
+  key_name                    = local.ssh_enabled ? aws_key_pair.ssh_key[0].id : null
   security_groups = compact([
     aws_security_group.nomad_sg[0].id,
     local.ssh_enabled ? aws_security_group.ssh_sg[0].id : "",

--- a/eks/nomad/variables.tf
+++ b/eks/nomad/variables.tf
@@ -30,10 +30,16 @@ variable "vpc_id" {
 variable "vpc_zone_identifier" {
 }
 
+variable "private_clients" {
+  type        = bool
+  default     = false
+  description = "Determine whether to assign public IPv4 addresses to the Nomad clients or not. Make sure that this setting matches the settings for the subnets passed in via `vpc_zone_identifier`"
+}
+
 variable "ssh_allowed_cidr_blocks" {
   type        = list(string)
   default     = ["0.0.0.0/0"]
-  description = "List of allowed source IP addresses that can access Nomad clients via SSH. Has no effict if `ssh_key` not set."
+  description = "List of allowed source IP addresses that can access Nomad clients via SSH. Has no effect if `ssh_key` not set."
 }
 
 variable "ssh_key" {
@@ -45,5 +51,5 @@ variable "ssh_key" {
 variable "enable_mtls" {
   type        = bool
   default     = true
-  description = "MTLS support for Nomad traffic. Modifying this can be dangerous and is not recommended."
+  description = "mTLS support for Nomad traffic. Modifying this can be dangerous and is not recommended."
 }

--- a/eks/terraform.tfvars.template
+++ b/eks/terraform.tfvars.template
@@ -23,11 +23,11 @@ k8s_administrators  = []    # add any AWS users here who should also have access
 
 nomad_count   = 1
 nomad_ssh_key = null  # Set to valid SSH public key to enable SSH access to nomad clients
-private_nomad_clients = false
 # Setting `private_nomad_clients` to true will cause Nomad clients to be deployed into private subnets and no public IPv4 addresses will be assigned to them
 # If you set this to true, the following limitations will apply:
 # * "Rerun job with SSH" functionality will be broken
-# * You will need a VPN or jump host to SSH into the Nomad client if you have set an SSH key above. SSH access will still be limited by `allowed_cidr_blocks`, so include the IP address of your VPN gateway or jump host.
+# * If `nomad_ssh_key` is set, you can still SSH into the nomad client machines from within the VPC.  Access will still be limited by `allowed_cidr_blocks`.  This configuration is beyond the scope of this project.
+private_nomad_clients = false
 
 # Cluster node details - uncomment to manage node type and numbers. Below are the default values so if these are fine no need to uncomment
 # instance_type      = "m4.xlarge"

--- a/eks/terraform.tfvars.template
+++ b/eks/terraform.tfvars.template
@@ -23,9 +23,14 @@ k8s_administrators  = []    # add any AWS users here who should also have access
 
 nomad_count   = 1
 nomad_ssh_key = null  # Set to valid SSH public key to enable SSH access to nomad clients
+private_nomad_clients = false
+# Setting `private_nomad_clients` to true will cause Nomad clients to be deployed into private subnets and no public IPv4 addresses will be assigned to them
+# If you set this to true, the following limitations will apply:
+# * "Rerun job with SSH" functionality will be broken
+# * You will need a VPN or jump host to SSH into the Nomad client if you have set an SSH key above. SSH access will still be limited by `allowed_cidr_blocks`, so include the IP address of your VPN gateway or jump host.
 
 # Cluster node details - uncomment to manage node type and numbers. Below are the default values so if these are fine no need to uncomment
 # instance_type      = "m4.xlarge"
-# max_capacity       = 5
-# min_capacity       = 4
-# desired_capacity   = 4   # Changes to this value are not respected by terraform and must be done manually through the console per: https://github.com/terraform-aws-modules/terraform-aws-eks/issues/835
+# max_capacity       = 7
+# min_capacity       = 5
+# desired_capacity   = 5   # Changes to this value are not respected by terraform and must be done manually through the console per: https://github.com/terraform-aws-modules/terraform-aws-eks/issues/835

--- a/eks/terraform.tfvars.template
+++ b/eks/terraform.tfvars.template
@@ -24,8 +24,8 @@ k8s_administrators  = []    # add any AWS users here who should also have access
 nomad_count   = 1
 nomad_ssh_key = null  # Set to valid SSH public key to enable SSH access to nomad clients
 # Setting `private_nomad_clients` to true will cause Nomad clients to be deployed into private subnets and no public IPv4 addresses will be assigned to them
-# If you set this to true, the following limitations will apply:
-# * "Rerun job with SSH" functionality will be broken
+# If you set this to true,
+# * "Rerun job with SSH" functionality will only be reachable from within the IP using the Nomad client's private IP address
 # * If `nomad_ssh_key` is set, you can still SSH into the nomad client machines from within the VPC.  Access will still be limited by `allowed_cidr_blocks`.  This configuration is beyond the scope of this project.
 private_nomad_clients = false
 

--- a/eks/variables.tf
+++ b/eks/variables.tf
@@ -103,6 +103,12 @@ variable "nomad_ssh_key" {
   description = "SSH key to authenticate access to Nomad clients. If not set SSH access is disabled"
 }
 
+variable "private_nomad_clients" {
+  type        = bool
+  default     = false
+  description = "Set this to true to have Nomad clients deployed into a private subnet without public IPv4 addresses"
+}
+
 variable "instance_type" {
   type        = string
   default     = "m4.xlarge"
@@ -111,19 +117,19 @@ variable "instance_type" {
 
 variable "max_capacity" {
   type        = number
-  default     = 5
+  default     = 7
   description = "The maximun number of worker nodes in the cluster"
 }
 
 variable "min_capacity" {
   type        = number
-  default     = 4
+  default     = 5
   description = "The minimum number of worker nodes in the cluster"
 }
 
 variable "desired_capacity" {
   type        = number
-  default     = 4
+  default     = 5
   description = "The desired number of worker nodes in the cluster.  Changes to this value are not respected by terraform per: https://github.com/terraform-aws-modules/terraform-aws-eks/issues/835"
 }
 

--- a/shared/nomad-scripts/nomad-startup.sh.tpl
+++ b/shared/nomad-scripts/nomad-startup.sh.tpl
@@ -56,6 +56,21 @@ service docker restart
 sleep 5
 
 echo "--------------------------------------"
+echo " Populating /etc/circleci/public-ipv4"
+echo "--------------------------------------"
+if [ $CLOUD_PROVIDER == "AWS" ]; then
+    export aws_instance_metadata_url="http://169.254.169.254"
+    export PUBLIC_IP="$(curl $aws_instance_metadata_url/latest/meta-data/public-ipv4)"
+    export PRIVATE_IP="$(curl $aws_instance_metadata_url/latest/meta-data/local-ipv4)"
+    if ! (echo $PUBLIC_IP | grep -qP "^[\d.]+$"); then
+        echo "Setting the IPv4 address below in /etc/circleci/public-ipv4."
+        echo "This address will be used in builds with \"Rebuild with SSH\"."
+        mkdir -p /etc/circleci
+        echo $PRIVATE_IP | tee /etc/circleci/public-ipv4
+    fi
+fi
+
+echo "--------------------------------------"
 echo "         Installing nomad"
 echo "--------------------------------------"
 apt-get install -y zip


### PR DESCRIPTION
This adds an option to have Nomad clients deployed to a private subnet
with no public IPs assigned to them. The limitations this entails have
been documented in the `terraform.tfvars.template` file.

Furthermore, some typos were fixed and the k8s cluster node count
amended to satisfy increased preflight check demands

Checks conducted:
* Nomad clients don't have public IPs assigned to them
* Jobs can still be run successfully, even if they need to pull images etc
