### PR TITLE
Use public k8s endpoint by default, disable bastion

### DIFF
--- a/eks/cluster.tf
+++ b/eks/cluster.tf
@@ -23,8 +23,8 @@ module "eks-cluster" {
   source                          = "terraform-aws-modules/eks/aws"
   cluster_name                    = local.cluster_name
   cluster_version                 = local.k8s_version
-  cluster_endpoint_private_access = var.enable_bastion ? true : false
-  cluster_endpoint_public_access  = true
+  cluster_endpoint_private_access = var.enable_k8s_private_endpoint
+  cluster_endpoint_public_access  = var.enable_k8s_public_endpoint
   vpc_id                          = module.vpc.vpc_id
   subnets                         = module.vpc.private_subnets
   cluster_enabled_log_types       = ["api", "audit", "authenticator", "controllerManager", "scheduler"]

--- a/eks/managing_user_access.md
+++ b/eks/managing_user_access.md
@@ -22,6 +22,8 @@ k8s_administrators = [
 }
 ```
 
+Note: For this to work, the machine running the terraform will need access to the K8s API. If you only enable the private k8s endpoint and your machine cannot access your VPN, terraform will be unable to apply the user mapping to the cluster.
+
 
 ### Updating the Cluster admin list
 If you wish to add/remove admin users from your existing cluster, you only need to update the values in your `terraform.tfvars` and run `terrafrom apply`.

--- a/eks/terraform.tfvars.template
+++ b/eks/terraform.tfvars.template
@@ -1,8 +1,14 @@
 basename         = ""        # Prefix added to cluster resources
 aws_region       = ""        # Region to create cluster IE us-east-1
 
-enable_bastion   = true      # Enable a bastion host for the eks cluster
+enable_bastion   = false      # Enable a bastion host for the eks cluster [DEPRECATED - will be removed in the next release]
 bastion_key      = ""        # cat the public ssh key to use for the bastion host.
+
+# If you disable the public endpoint, ensure that the machine running the terraform can access the private endpoint, e.g.
+# by using a bastion host or a VPN connection into the VPC.
+# Otherwise setting up the EKS cluster will fail. Disabling access to both endpoints will result in an inoperable cluster
+enable_k8s_public_endpoint  = true  # Enable authenticated access to the k8s API from the public internet
+enable_k8s_private_endpoint = true  # Enable authenticated access to the k8s API from within the VPC
 
 # The CIDR ranges that are allowed to access the Kubernetes cluster.
 # Developers, this is typically the public IP address of your home/office network

--- a/eks/variables.tf
+++ b/eks/variables.tf
@@ -18,7 +18,19 @@ variable "aws_region" {
 }
 
 variable "enable_bastion" {
-  default = true
+  default = false
+}
+
+variable "enable_k8s_private_endpoint" {
+  type        = bool
+  default     = true
+  description = "Determines whether the k8s API endpoint is reachable within the VPC"
+}
+
+variable "enable_k8s_public_endpoint" {
+  type        = bool
+  default     = true
+  description = "Determines whether the k8s API endpoint is reachable from the public internet"
 }
 
 variable "k8s_administrators" {

--- a/gke/README.md
+++ b/gke/README.md
@@ -49,7 +49,7 @@ curl https://kots.io/install | bash
 
 ## Deploy GKE Infrastructure with Terraform
 
-This assumes the default configuration with a private cluster behind a bastion host.
+This assumes the default configuration using the public k8s endpoint
 
 1. Configure Google Cloud credentials. You can do this in one of two ways:
     * Set up [user default application credentials]  via `gcloud auth
@@ -80,21 +80,11 @@ and removals.
 10. Once the plan has been verified, run command: `terraform apply` And when
     prompted, confirm the deployment. Deployment time can vary but has
 typically taken approximately ten minutes.
-11. Once deployment is complete, Terraform will display the name of the bastion host and the name and IP of the cluster. You can now connect to your bastion host:
-
-`gcloud compute ssh <bastion-host-name> --project <project-name> --region <region-name>`
-
-The `--project` and `--region` flags can be omitted if `gcloud` the default values configured during initialization can be used. If you have previously used service account credentials, switch back to use your user account credentials before connecting to the bastion: `gcloud auth login`.
-
-You will need to connect to the bastion whenever you need to access the cluster or some of its components.
-
-12. On the bastion, initialize gcloud: `gcloud init` – please make sure that you are using your own credentials and not the bastion host's Service Account. The Service Account doesn't have any relevant permissions and will prevent you from working effectively on the cluster.
-
-13. Add the new GKE cluster to the Kubernetes configuration via gcloud by running the following command:
+11. Add the new GKE cluster to the Kubernetes configuration via gcloud by running the following command:
 ```
 gcloud container clusters get-credentials [CLUSTER NAME]
 ```
-14. Verify that the credentials were added by running the following command:
+12. Verify that the credentials were added by running the following command:
     `kubectl config get-contexts` This should return a list of contexts with an
 asterisk beside the active context.
 
@@ -152,6 +142,9 @@ The leading `--` says "pass the following arguments down to the underlying
 `ssh` command" when you run `gcloud compute ssh....`. The `-A` tells `ssh` to
 forward creds to the next machine for you so that you don't have to copy a key
 around.
+
+Alternatively, you may set up a VPN connection into your VPC to access resources
+using their internal IPs.
 
 <!-- Links -->
 [terraform]: https://releases.hashicorp.com/terraform/0.14.2/

--- a/gke/managing_user_access.md
+++ b/gke/managing_user_access.md
@@ -1,28 +1,9 @@
 # Managing Access to your Kubernetes cluster
 The following document assumes you have used the terraform scripts found in this repository to create a Kubernetes cluster for your CircleCI server installation. Below we go through our recommended approach to providing and managing user access.
 
-
-## Overview
-
-We recommend making only the bastion host accessible from the public internet. Thus, you can remove most risk of unauthorized access by simply stopping your bastion host while not in use. This will also give you two layers of access control:
-* Who can connect to the bastion host
-* What can a user do on the bastion host
-
-## Managing bastion host SSH access
-
-The bastion host has OS Login enabled which allows you to manage SSH access to the bastion using the IAM controls in GCP. Users with `roles/owner`, `roles/editor` or `roles/compute.instanceAdmin` permissions will automatically have administrator permissions, i.e. they may perform `sudo` commands on the bastion.  You can grant other users within the project access with the `roles/compute.osLogin` permission or sudo access with the `roles/compute.osAdminLogin` permission. Users should also have the `roles/iam.serviceAccountUser` role on the service account as this is the account the bastion host itself uses to authenticate against other services, e.g. the Kubernetes cluster. You can attach conditions to the role to ensure that users can impersonate the Service Account only on the bastion host.
-
-This approach has the advantages that you don't need to manage SSH keys manually and that deactivating an IAM user will also prevent them from connecting to the bastion host. For this to work, a user needs to use Google's `glcoud` tool. Assuming a user has initialized gcloud (`gcloud init`), they can simply connect to the bastion using
-
-`gcloud compute ssh <bastion-host-name> --project <project-name> --region <region-name>`
-
-The `--project` and `--region` flags can be omitted if `gcloud` there were default values configured during initialization that can be used.
-
 ## Adding Users with Limited Resource Access
 You may not wish for each user to have access to all cluster resources. To finely tune user access we make use of kubernetes' role based access control ([RBAC]).
 In the following example we will create a role that will have limited access to a `develop` namespace and then map it to an IAM user. You will need to be a cluster administrator as detailed above to proceed with the following steps.
-
-On the bastion host, make sure that your `kubectl` config is up-to-date and that you have all the necessary permissions.
 
 1. First, we'll create a `role` that may only read pod data in the `develop` namespace.
 - create a file called `read-role.yaml` and add the following:
@@ -65,8 +46,7 @@ roleRef:
 - and then apply the role-binding to your cluster:
 `kubectl apply -f read-role-binding.yaml`
 
-
-Now your user will be able to access the cluster from the bastion but will only be able to view pod resources in the `develop` namespace.
+Now your user will be able to access the cluster but will only be able to view pod resources in the `develop` namespace.
 
 For more details on managing permissions, you may read Google's [RBAC] documentation.
 

--- a/gke/terraform.tfvars.template
+++ b/gke/terraform.tfvars.template
@@ -14,25 +14,26 @@ node_auto_upgrade = true
 initial_nodes     = 1
 
 enable_nat                     = true
-enable_bastion                 = true
+enable_bastion                 = false # [DEPRECATED - will be removed in the next release]
 enable_istio                   = false
 enable_intranode_communication = false
 enable_dashboard               = false
-private_k8s_endpoint           = true
-private_vms                    = true
+# WARNING: Modifying `private_k8s_endpoint` after the cluster has been stood up
+# will DESTROY AND RECREATE the cluster, causing LOSS OF DATA
+private_k8s_endpoint           = false
+private_vms                    = false
 
 # The CIDR ranges that are allowed to access those components of your
-# installation that should be accessible via the public internet. By default
-# this is only the bastion host. Developers, this is typically the public IP
-# address of your home/office network IE [ "1.2.3.4/32" ]. By default, access is
-# only available through the bastion host.
+# installation that should be accessible via the public internet.
+# Developers, this is typically the public IP address of your home/office
+# network IE [ "1.2.3.4/32" ].
 allowed_cidr_blocks = []
 
 nomad_count   = 1
 
 # Set to true to allow SSH access to Nomad clients via the public internet.
 # Use `gcloud compute ssh` to manage keys
-nomad_ssh_enabled = false
+nomad_ssh_enabled = true
 # Who can use the Nomad ServiceAccount, e.g. for managing SSH keys on Nomad
 # clients. Can be `user:{emailid}` for a single user, `group:{emailid}` for a
 # Google group, or `allAuthenticatedUsers` to allow all authenticated users

--- a/gke/variables.tf
+++ b/gke/variables.tf
@@ -75,7 +75,7 @@ variable "enable_nat" {
 
 variable "enable_bastion" {
   type        = bool
-  default     = true
+  default     = false
   description = "Include a bastion/jump server in deployment. You can restrict the range of IPs that can connect to the bastion using `allowed_cidr_blocks`"
 }
 
@@ -105,14 +105,14 @@ variable "enable_dashboard" {
 
 variable "private_k8s_endpoint" {
   type        = bool
-  default     = true
-  description = "By default, the Kubernetes endpoint is only accessible via the bastion host. Set to false if you want access via the public internet. You can use IP whitelisting using `allowed_cidr_blocks` to tighten access for both cases."
+  default     = false
+  description = "Setting this to true will disable access to the k8s API via the public internet. You will need a bastion or VPN to operate the k8s cluster"
 }
 
 variable "private_vms" {
   type        = bool
-  default     = true
-  description = "By default, the VMs for the remote docker and machine executors are only accessible via the bastion host. Set to false if you want access via the public internet, in which case you will need to whitelist IPs using `allowed_cidr_blocks`"
+  default     = false
+  description = "Set to true to isolate VMs for `machine` and `remote_docker` executors from the public internet"
 }
 
 
@@ -129,8 +129,8 @@ variable "nomad_count" {
 
 variable "nomad_ssh_enabled" {
   type        = bool
-  default     = false
-  description = "Enables SSH to Nomad clients. If enabled, use `gcloud compute ssh` to manage SSH keys. If you use a bastion host and a private endpoint, you can still connect to Nomad clients with this value set to `false` via the bastion host using their private IPs"
+  default     = true
+  description = "Set to true this creates a firewall rule that allows TCP access on port 22 for the IPs whitelisted in `allowed_cidr_blocks` for SSH access. When set to false, SSH access is still possible by using a VPN or bastion host."
 }
 
 variable "nomad_sa_access" {
@@ -142,5 +142,5 @@ variable "nomad_sa_access" {
 variable "enable_mtls" {
   type        = bool
   default     = true
-  description = "MTLS support for Nomad traffic. Modifying this can be dangerous and is not recommended."
+  description = "mTLS support for Nomad traffic. Modifying this can be dangerous and is not recommended."
 }


### PR DESCRIPTION
This changes the default access pattern from a setup where resources are
private by default and can only be accessed via a bastion host to an
all-public approach. It is the user's responsibility to secure access to
their resources.

The documentation has been updated to reflect this.

Tests:
[x] Checked if clusters exhibit expected access restrictions on GKE, EKS
[x] Checked if modifying endpoint access in EKS is non-destructive
