### PR TITLE
[SERVER-611] Set Nomad Client base AMI to Ubuntu 20.04 Focal

### DIFF
--- a/eks/ami.tf
+++ b/eks/ami.tf
@@ -1,0 +1,10 @@
+data "aws_ami" "ubuntu-20_04-focal" {
+  most_recent = true
+
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*"]
+  }
+
+  owners = ["099720109477"]
+}

--- a/eks/nomad.tf
+++ b/eks/nomad.tf
@@ -1,7 +1,7 @@
 module "nomad" {
   source = "./nomad"
 
-  ami_id                  = var.ubuntu_ami[var.aws_region]
+  ami_id                  = var.nomad_ami_id != "" ? var.nomad_ami_id : data.aws_ami.ubuntu-20_04-focal.id
   aws_subnet_cidr_block   = module.vpc.vpc_cidr_block
   basename                = var.basename
   enable_mtls             = var.enable_mtls

--- a/eks/nomad/variables.tf
+++ b/eks/nomad/variables.tf
@@ -20,8 +20,7 @@ variable "nomad_count" {
 }
 
 variable "ami_id" {
-  default     = "ami-0cfee17793b08a293"
-  description = "Default Ubuntu ami for us-east-1"
+  description = "AMI used as the base operating system."
 }
 
 variable "vpc_id" {

--- a/eks/variables.tf
+++ b/eks/variables.tf
@@ -150,3 +150,9 @@ variable "enable_mtls" {
   default     = true
   description = "MTLS support for Nomad traffic. Modifying this can be dangerous and is not recommended."
 }
+
+variable "nomad_ami_id" {
+  type        = string
+  default     = ""
+  description = "Base AMI used for the Nomad client "
+}

--- a/gke/nomad.tf
+++ b/gke/nomad.tf
@@ -2,6 +2,7 @@ module "nomad" {
   source = "./nomad"
 
   basename                = var.basename
+  source_image            = var.nomad_source_image
   enable_mtls             = var.enable_mtls
   network_name            = google_compute_network.circleci_net.name
   nomad_count             = var.nomad_count

--- a/gke/nomad/main.tf
+++ b/gke/nomad/main.tf
@@ -70,7 +70,7 @@ resource "google_compute_instance_template" "nomad_template" {
   }
 
   disk {
-    source_image = "ubuntu-os-cloud/ubuntu-1604-lts"
+    source_image = var.source_image
     disk_size_gb = 500
     boot         = true
     auto_delete  = true

--- a/gke/nomad/variables.tf
+++ b/gke/nomad/variables.tf
@@ -54,3 +54,8 @@ variable "enable_mtls" {
   default     = true
   description = "MTLS support for Nomad traffic. Modifying this can be dangerous and is not recommended."
 }
+
+variable "source_image" {
+  type        = string
+  description = "Base operating system image "
+}

--- a/gke/variables.tf
+++ b/gke/variables.tf
@@ -151,3 +151,9 @@ variable "enable_mtls" {
   default     = true
   description = "mTLS support for Nomad traffic. Modifying this can be dangerous and is not recommended."
 }
+
+variable "nomad_source_image" {
+  type        = string
+  default     = "ubuntu-os-cloud/ubuntu-2004-lts"
+  description = "The base OS image used by the Nomad clients."
+}

--- a/shared/nomad-scripts/nomad-startup.sh.tpl
+++ b/shared/nomad-scripts/nomad-startup.sh.tpl
@@ -75,7 +75,7 @@ echo "--------------------------------------"
 echo "         Installing nomad"
 echo "--------------------------------------"
 apt-get install -y zip
-curl -o nomad.zip https://releases.hashicorp.com/nomad/0.11.3/nomad_0.11.3_linux_amd64.zip
+curl -o nomad.zip https://releases.hashicorp.com/nomad/0.11.8/nomad_0.11.8_linux_amd64.zip
 unzip nomad.zip
 mv nomad /usr/bin
 

--- a/shared/nomad-scripts/nomad-startup.sh.tpl
+++ b/shared/nomad-scripts/nomad-startup.sh.tpl
@@ -42,7 +42,8 @@ curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
 add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
 apt-get install -y "linux-image-$UNAME"
 apt-get update
-apt-get -y install docker-ce=5:18.09.1~3-0~ubuntu-xenial
+apt-get -y install docker-ce=5:19.03.13~3-0~ubuntu-focal \
+                   docker-ce-cli=5:19.03.13~3-0~ubuntu-focal
 
 # force docker to use userns-remap to mitigate CVE 2019-5736
 apt-get -y install jq


### PR DESCRIPTION
This change sets the base image for the Nomad client to Ubuntu 20.04
Focal. The mechanism in which the image is selected has been altered.

Originally, we used the ubuntu_ami map located in the variables.tf
file located in the EKS root directory. The region would be passed
to the map and the proper AMI was derived from the map.

This change adds `ami.tf` which will perform a lookup against the
Ubuntu AWS AMI list and determine which AMI to use based on the
criteria set in the filter. This value is then made available to the
`ami_id` variable in the `nomad.tf` file.

The `ami_id` was slightly altered to allow the user to provide their
own AMI id. However, it defaults to the auto-selection outlined
above if the variable is not defined.