### PR TITLE
Add option for preemptible nodes

### DIFF
--- a/gke/main.tf
+++ b/gke/main.tf
@@ -29,6 +29,7 @@ module "kube_private_cluster" {
   node_tags = []
 
   # Node pool configuration
+  preemptible_nodes  = var.preemptible_k8s_nodes
   nodes_machine_spec = var.node_spec
   node_min           = var.node_min
   node_max           = var.node_max

--- a/gke/private_kubernetes/main.tf
+++ b/gke/private_kubernetes/main.tf
@@ -119,6 +119,7 @@ resource "google_container_node_pool" "node_pool" {
   initial_node_count = var.initial_nodes
 
   node_config {
+    preemptible     = var.preemptible_nodes
     machine_type    = var.nodes_machine_spec
     service_account = google_service_account.k8s_service_account.email
     oauth_scopes    = ["cloud-platform"]

--- a/gke/private_kubernetes/variables.tf
+++ b/gke/private_kubernetes/variables.tf
@@ -129,3 +129,9 @@ variable "private_vms" {
 variable "privileged_bastion" {
   type = bool
 }
+
+variable "preemptible_nodes" {
+  type        = bool
+  default     = false
+  description = "Use preemptible nodes for cluster. Keeps cost low for development or proof of concept cluster"
+}

--- a/gke/variables.tf
+++ b/gke/variables.tf
@@ -109,6 +109,13 @@ variable "private_k8s_endpoint" {
   description = "Setting this to true will disable access to the k8s API via the public internet. You will need a bastion or VPN to operate the k8s cluster"
 }
 
+
+variable "preemptible_k8s_nodes" {
+  type        = bool
+  default     = false
+  description = "Use preemptible nodes for cluster. Keeps cost low for development or proof of concept cluster"
+}
+
 variable "private_vms" {
   type        = bool
   default     = false


### PR DESCRIPTION
The cloud is expensive! This work adds an option to use preemptible nodes in GCP to lower the cost of a Server deployment. This is primarily intended for development and pre-prod environments as we don't have perfect HA in Server yet.

- Ticket: None
- Change type: Cost control 💸 
- Testing checklist
  - [ ] New install works (reality checked)
  - [ ] Change to preemptible nodes works (down time ok)
  - [ ] Change from preemptible nodes works (down time ok)