### PR TITLE
Fix nomad startup script

### DIFF
--- a/shared/nomad-scripts/nomad-startup.sh.tpl
+++ b/shared/nomad-scripts/nomad-startup.sh.tpl
@@ -240,11 +240,12 @@ docker_chain="DOCKER-USER"
 if [ "$CLOUD_PROVIDER" == "GCP" ]; then
     /sbin/iptables --wait --insert $docker_chain 1 -i br+ --destination 169.254.169.254/32 -p tcp --dport 53 --jump RETURN # Allow DNS queries
     /sbin/iptables --wait --insert $docker_chain 2 -i br+ --destination 169.254.169.254/32 -p udp --dport 53 --jump RETURN # Allow DNS queries
-else if [ "$CLOUD_PROVIDER" == "AWS" ]; then
+elif [ "$CLOUD_PROVIDER" == "AWS" ]; then
     /sbin/iptables --wait --insert $docker_chain 1 -i br+ --destination 169.254.169.253/32 -p tcp --dport 53 --jump RETURN # Allow DNS queries
     /sbin/iptables --wait --insert $docker_chain 2 -i br+ --destination 169.254.169.253/32 -p udp --dport 53 --jump RETURN # Allow DNS queries
 fi
-/sbin/iptables --wait --insert $docker_chain 3 -i docker+ --destination 169.254.0.0/16 --jump DROP
-/sbin/iptables --wait --insert $docker_chain 4 -i br-+ --destination 169.254.0.0/16 --jump DROP
+/sbin/iptables --wait --insert $docker_chain 3 -i docker+ --destination "169.254.0.0/16" --jump DROP
+/sbin/iptables --wait --insert $docker_chain 4 -i br-+ --destination "169.254.0.0/16" --jump DROP
+# We probably want to ditch the assumption here that the cluster will live at 10.0.0.0/8 and replace it with a variable
 /sbin/iptables --wait --insert $docker_chain 5 -i docker+ --destination "10.0.0.0/8" --jump DROP
 /sbin/iptables --wait --insert $docker_chain 6 -i br+ --destination "10.0.0.0/8" --jump DROP


### PR DESCRIPTION
A syntax error in the startup script prevented IP tables rules from being applied properly