### PR TITLE
Use separate subnets for different components [EKS]

### DIFF
--- a/eks/cluster.tf
+++ b/eks/cluster.tf
@@ -26,7 +26,7 @@ module "eks-cluster" {
   cluster_endpoint_private_access = var.enable_k8s_private_endpoint
   cluster_endpoint_public_access  = var.enable_k8s_public_endpoint
   vpc_id                          = module.vpc.vpc_id
-  subnets                         = module.vpc.private_subnets
+  subnets                         = local.cluster_subnets
   cluster_enabled_log_types       = ["api", "audit", "authenticator", "controllerManager", "scheduler"]
   wait_for_cluster_cmd            = "for i in `seq 1 60`; do curl -k -s $ENDPOINT/healthz >/dev/null && exit 0 || true; sleep 5; done; echo TIMEOUT && exit 1"
   map_roles = var.enable_bastion ? concat(

--- a/eks/nomad.tf
+++ b/eks/nomad.tf
@@ -1,6 +1,9 @@
-module "nomad" {
-  source = "./nomad"
+data "aws_subnet" "vm_subnet" {
+  id = local.vm_subnet
+}
 
+module "nomad" {
+  source                  = "./nomad"
   ami_id                  = var.nomad_ami_id != "" ? var.nomad_ami_id : data.aws_ami.ubuntu-20_04-focal.id
   aws_subnet_cidr_block   = module.vpc.vpc_cidr_block
   basename                = var.basename
@@ -11,6 +14,8 @@ module "nomad" {
   ssh_allowed_cidr_blocks = var.allowed_cidr_blocks
   ssh_key                 = var.nomad_ssh_key
   vpc_id                  = module.vpc.vpc_id
-  vpc_zone_identifier     = var.private_nomad_clients ? module.vpc.private_subnets : module.vpc.public_subnets
+  vpc_zone_identifier     = local.nomad_subnets
+  vpc_cidr                = module.vpc.vpc_cidr_block
+  vm_subnet_cidr          = data.aws_subnet.vm_subnet.cidr_block
   private_clients         = var.private_nomad_clients
 }

--- a/eks/nomad/main.tf
+++ b/eks/nomad/main.tf
@@ -49,6 +49,8 @@ module "asg" {
     {
       basename        = var.basename
       cloud_provider  = "AWS"
+      vpc_cidr        = var.vpc_cidr
+      vm_subnet_cidr  = var.vm_subnet_cidr
       client_tls_cert = var.enable_mtls ? module.nomad_tls[0].nomad_client_cert : ""
       client_tls_key  = var.enable_mtls ? module.nomad_tls[0].nomad_client_key : ""
       tls_ca          = var.enable_mtls ? module.nomad_tls[0].nomad_tls_ca : ""

--- a/eks/nomad/variables.tf
+++ b/eks/nomad/variables.tf
@@ -29,6 +29,16 @@ variable "vpc_id" {
 variable "vpc_zone_identifier" {
 }
 
+variable "vpc_cidr" {
+  type        = string
+  description = "The CIDR block of the VPC to prevent access from jobs"
+}
+
+variable "vm_subnet_cidr" {
+  type        = string
+  description = "The CIDR block of the VM subnet to enable jobs to run on external VMs"
+}
+
 variable "private_clients" {
   type        = bool
   default     = false

--- a/eks/outputs.tf
+++ b/eks/outputs.tf
@@ -7,7 +7,7 @@ output "region" {
 }
 
 output "subnet" {
-  value = module.vpc.private_subnets[0]
+  value = local.vm_subnet
 }
 
 output "bastion_public_ip" {

--- a/eks/variables.tf
+++ b/eks/variables.tf
@@ -145,13 +145,13 @@ variable "max_capacity" {
 
 variable "min_capacity" {
   type        = number
-  default     = 6
+  default     = 5
   description = "The minimum number of worker nodes in the cluster"
 }
 
 variable "desired_capacity" {
   type        = number
-  default     = 6
+  default     = 5
   description = "The desired number of worker nodes in the cluster.  Changes to this value are not respected by terraform per: https://github.com/terraform-aws-modules/terraform-aws-eks/issues/835"
 }
 

--- a/gke/nomad/main.tf
+++ b/gke/nomad/main.tf
@@ -62,6 +62,8 @@ resource "google_compute_instance_template" "nomad_template" {
       client_tls_cert = var.enable_mtls ? module.nomad_tls[0].nomad_client_cert : ""
       client_tls_key  = var.enable_mtls ? module.nomad_tls[0].nomad_client_key : ""
       tls_ca          = var.enable_mtls ? module.nomad_tls[0].nomad_tls_ca : ""
+      vpc_cidr        = ""
+      vm_subnet_cidr  = ""
     }
   )
 


### PR DESCRIPTION
This commit increases security by ensuring that cluster nodes, Nomad clients
and external VMs do not share subnets in EKS.

The subnets are distributed so that Nomad clients get half of the subnets
(rounded up if necessary), VMs all go into the same subnet and the cluster
nodes get the remaining subnets. If the Nomad clients are deployed to public
subnets, the all the private subnets can be used for cluster nodes except one
private subnet that is reserved for the VMs.

The Nomad clients now block all access from jobs to any VPC IP, except the CIDR
block for the subnet of the VMs and the VPC DNS server. This blocks all access
to any internal services and IPs from within standard jobs. ~It does not work
for jobs on external VMs, though.~ UPDATE: Using NACL rules, I was able to block
most traffic to pods. Directly cURL-ing the APIs of the services no longer works in
jobs running on external VMs

The following cURLs do not succeed from jobs with the changes applied, neither in Nomad jobs nor on external VMs with machine executor (they did previously):
- Any cURLs to the Nomad server on port 4646, regardless if via AWS DNS name of the loadbalancer, the internal DNS record, the service's IP or the Pod IP - using a release that still exposed that port on the LB
- Any cURLs to other services via internal DNS, e.g. VM service

Realitycheck still succeeds