### PR TITLE
Correct org name

### DIFF
--- a/eks/README.md
+++ b/eks/README.md
@@ -26,7 +26,7 @@ configure the CircleCI Server application:
 1. Install any missing CLI tools listed above. Ensure access to listed
    services.
 2. Clone `server-terraform` repository to your machine. `git clone
-   git@github.com:circleci/server-terraform.git`
+   git@github.com:circleci-public/server-terraform.git`
 3. Assume going forward that all paths specified are relative to the root of
    the `server-terraform` repo.
 


### PR DESCRIPTION
Clone command in `## Setup` refers to incorrect org