### PR TITLE
RE-774: Install support-bundle plugin on bastion

### DIFF
--- a/gke/private_kubernetes/extra-vms.tf
+++ b/gke/private_kubernetes/extra-vms.tf
@@ -57,6 +57,7 @@ resource "google_compute_instance" "bastion" {
     "echo \"gcloud container clusters get-credentials --internal-ip --region ${var.location} ${var.unique_name}-k8s-cluster\" > update-kubeconfig && chmod +x update-kubeconfig && sudo mv ./update-kubeconfig /usr/bin/update-kubeconfig && update-kubeconfig",
     "curl -LO https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv3.8.8/kustomize_v3.8.8_linux_amd64.tar.gz && tar xzf ./kustomize_v3.8.8_linux_amd64.tar.gz && sudo mv ./kustomize /usr/bin/",
     "curl -LO https://github.com/replicatedhq/kots/releases/download/v1.25.2/kots_linux_amd64.tar.gz && tar xzf kots_linux_amd64.tar.gz && sudo mv ./kots /usr/bin/kubectl-kots",
-    "curl -LO https://github.com/replicatedhq/troubleshoot/releases/download/v0.9.54/preflight_linux_amd64.tar.gz && tar xzf preflight_linux_amd64.tar.gz && sudo mv ./preflight /usr/bin/kubectl-preflight"
+    "curl -LO https://github.com/replicatedhq/troubleshoot/releases/download/v0.9.54/preflight_linux_amd64.tar.gz && tar xzf preflight_linux_amd64.tar.gz && sudo mv ./preflight /usr/bin/kubectl-preflight",
+    "curl -LO https://github.com/replicatedhq/troubleshoot/releases/download/v0.9.55/support-bundle_linux_amd64.tar.gz && tar xzf support-bundle_linux_amd64.tar.gz && sudo mv ./support-bundle /usr/bin/kubectl-support_bundle"
   ])
 }


### PR DESCRIPTION
## Problem
We need to generate a support bundle in the ox-bot workflow pipeline where core services fails to deploy correctly

## Solution
Add the support-bundle plugin and download the support-bundle for the failed CCI Application deployment in the pipeline