### PR TITLE
Fix firewall rules for SSH'ing into jobs [GCP]

### DIFF
--- a/gke/main.tf
+++ b/gke/main.tf
@@ -41,6 +41,7 @@ module "kube_private_cluster" {
 
   # Network configuration
   allowed_external_cidr_blocks   = var.allowed_cidr_blocks
+  ssh_jobs_allowed_cidr_blocks   = var.ssh_jobs_allowed_cidr_blocks
   enable_nat                     = var.enable_nat
   enable_bastion                 = var.enable_bastion
   privileged_bastion             = var.privileged_bastion

--- a/gke/nomad/main.tf
+++ b/gke/nomad/main.tf
@@ -105,19 +105,6 @@ resource "google_compute_firewall" "nomad_ssh" {
   network       = var.network_name
 }
 
-resource "google_compute_firewall" "nomad_job_ssh" {
-  name        = "${local.basename}-nomad-job-ssh"
-  description = "${local.basename} firewall rule for CircleCI Server Nomand component to allow SSH access to jobs"
-
-  allow {
-    protocol = "tcp"
-    ports    = ["64535-65535"]
-  }
-  source_ranges = var.ssh_allowed_cidr_blocks
-  target_tags   = ["nomad"]
-  network       = var.network_name
-}
-
 resource "google_compute_instance_group_manager" "nomad_manager" {
   depends_on         = [google_compute_instance_template.nomad_template]
   name               = "${local.basename}-nomad-manager"

--- a/gke/private_kubernetes/firewalls.tf
+++ b/gke/private_kubernetes/firewalls.tf
@@ -60,6 +60,22 @@ resource "google_compute_firewall" "allow_vm_machine_ports" {
   source_ranges = ["0.0.0.0/0"]
 }
 
+resource "google_compute_firewall" "allow_rerun_with_ssh" {
+  name        = "allow-rerun-with-ssh-ports-${var.unique_name}"
+  description = "${var.unique_name} firewall rule for CircleCI Server cluster component"
+  network     = var.network_uri
+  priority    = 900
+
+  allow {
+    protocol = "tcp"
+    ports    = ["64535-65535"]
+  }
+
+  target_tags = ["docker-machine", "nomad"]
+
+  source_ranges = var.ssh_jobs_allowed_cidr_blocks
+}
+
 resource "google_compute_firewall" "allow_bastion" {
   count       = var.enable_bastion ? 1 : 0
   name        = "allow-connections-to-${var.unique_name}-bastion"

--- a/gke/private_kubernetes/variables.tf
+++ b/gke/private_kubernetes/variables.tf
@@ -3,6 +3,12 @@ variable "allowed_external_cidr_blocks" {
   type = list(any)
 }
 
+variable "ssh_jobs_allowed_cidr_blocks" {
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
+  description = "This configures the allowable source IP blocks that may ssh into jobs using the 'rerun job with SSH' functionality."
+}
+
 variable "unique_name" {
   type = string
 }

--- a/gke/variables.tf
+++ b/gke/variables.tf
@@ -122,11 +122,16 @@ variable "private_vms" {
   description = "Set to true to isolate VMs for `machine` and `remote_docker` executors from the public internet"
 }
 
-
 variable "allowed_cidr_blocks" {
   type        = list(string)
   default     = []
   description = "This configures the allowable source IP blocks, depending on your configuration to your bastion host and/or Kubernetes cluster and/or Nomad clients and/or VMs"
+}
+
+variable "ssh_jobs_allowed_cidr_blocks" {
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
+  description = "This configures the allowable source IP blocks that may ssh into jobs using the 'rerun job with SSH' functionality."
 }
 
 variable "nomad_count" {


### PR DESCRIPTION
This adjusts firewall rules in GCP to open the ports needed to SSH'ing
into jobs using 'rerun with SSH' on external VMs and also uses a
separate IP whitelist for permissible source CIDR blocks. This whitelist
defaults to 0.0.0.0/0
