### PR TITLE
Use mq-deadline IO scheduler for root volume

### DIFF
--- a/shared/nomad-scripts/nomad-startup.sh.tpl
+++ b/shared/nomad-scripts/nomad-startup.sh.tpl
@@ -27,9 +27,12 @@ export INSTANCE_ID
 echo "----------------------------------------"
 echo "        Tuning kernel parameters"
 echo "----------------------------------------"
-echo 'mq-deadline' > /sys/block/nvme0n1/queue/scheduler
-echo 'GRUB_CMDLINE_LINUX_DEFAULT="console=tty1 console=ttyS0 nvme_core.io_timeout=4294967295 elevator=mq-deadline"' > /etc/default/grub.d/99-circleci-use-io-scheduler-for-nvme.cfg
-update-grub
+if [ -f /sys/block/nvme0n1/queue/scheduler ] && grep -q 'mq-deadline' /sys/block/nvme0n1/queue/scheduler
+then
+    echo 'mq-deadline' > /sys/block/nvme0n1/queue/scheduler
+    echo 'GRUB_CMDLINE_LINUX_DEFAULT="console=tty1 console=ttyS0 nvme_core.io_timeout=4294967295 elevator=mq-deadline"' > /etc/default/grub.d/99-circleci-use-io-scheduler-for-nvme.cfg
+    update-grub
+fi
 
 echo "-------------------------------------------"
 echo "     Performing System Updates"

--- a/shared/nomad-scripts/nomad-startup.sh.tpl
+++ b/shared/nomad-scripts/nomad-startup.sh.tpl
@@ -24,6 +24,13 @@ fi
 INSTANCE_ID=$(cloud-init query local_hostname)
 export INSTANCE_ID
 
+echo "----------------------------------------"
+echo "        Tuning kernel parameters"
+echo "----------------------------------------"
+echo 'mq-deadline' > /sys/block/nvme0n1/queue/scheduler
+echo 'GRUB_CMDLINE_LINUX_DEFAULT="console=tty1 console=ttyS0 nvme_core.io_timeout=4294967295 elevator=mq-deadline"' > /etc/default/grub.d/99-circleci-use-io-scheduler-for-nvme.cfg
+update-grub
+
 echo "-------------------------------------------"
 echo "     Performing System Updates"
 echo "-------------------------------------------"

--- a/shared/nomad-scripts/nomad-startup.sh.tpl
+++ b/shared/nomad-scripts/nomad-startup.sh.tpl
@@ -30,7 +30,7 @@ echo "----------------------------------------"
 if [ -f /sys/block/nvme0n1/queue/scheduler ] && grep -q 'mq-deadline' /sys/block/nvme0n1/queue/scheduler
 then
     echo 'mq-deadline' > /sys/block/nvme0n1/queue/scheduler
-    echo 'GRUB_CMDLINE_LINUX_DEFAULT="console=tty1 console=ttyS0 nvme_core.io_timeout=4294967295 elevator=mq-deadline"' > /etc/default/grub.d/99-circleci-use-io-scheduler-for-nvme.cfg
+    echo 'ACTION=="add|change", KERNEL=="nvme0n1", ATTR{queue/scheduler}="mq-deadline"' > /etc/udev/rules.d/99-circleci-io-scheduler.rules
     update-grub
 fi
 


### PR DESCRIPTION
Use `mq-deadline` IO scheduler for root volumes of Nomad clients which are visible as a NVMe device. See [this internal Slack discussion](https://circleci.slack.com/archives/CAT9Q7TGW/p1611911848093000?thread_ts=1610548657.306800&cid=CAT9Q7TGW) for technical details.