### PR TITLE
Accept newer AWS provider

### DIFF
--- a/eks/terraform.tf
+++ b/eks/terraform.tf
@@ -4,7 +4,7 @@ terraform {
       version = "~> 1.11"
     }
     aws = {
-      version = "~> 3.0.0"
+      version = ">= 3.0.0"
     }
   }
 }


### PR DESCRIPTION
Allow use of `aws` provider 3.10.0 or newer.

IIUC [recent change in AWS VPC Terraform module](https://github.com/terraform-aws-modules/terraform-aws-vpc/commit/4b83a66ef3eb0c7efc917f9c4dfee778b2002399) requires AWS provider 3.10.0 or newer, and without this patch `terraform init` will fail with the error message `Could not retrieve the list of available versions for provider hashicorp/aws:
no available releases match the given constraints ~> 3.0.0, >= 3.10.*, ...`.

I confirmed that the latest beta version running on the infrastructure built with this patch passes `realitycheck`.