### PR TITLE
Fix URI in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,10 @@ consume the AWS Nomad client module as follows:
 
 ```terraform
 module "my-aws-nomad-clients" {
-  source = "git::https://github.com/CircleCI-Public/server-terraform.git?ref=3.0.0-RC7//nomad-aws"
-    
+  # Pin release to 3.0.0-RC7 (for example) and use /nomad-aws subdirectory
+  source = "git::https://github.com/CircleCI-Public/server-terraform.git//nomad-aws?ref=3.0.0-RC7"
+  
+  # Other variables here... 
 }
 ```
 


### PR DESCRIPTION
Query string must come after path in URI