### PR TITLE
AWS specific nomad script

### DIFF
--- a/nomad-aws/main.tf
+++ b/nomad-aws/main.tf
@@ -47,9 +47,8 @@ resource "aws_instance" "nomad_client" {
   vpc_security_group_ids = length(var.security_group_id) != 0 ? var.security_group_id : local.nomad_security_groups
   key_name               = var.ssh_key != null ? aws_key_pair.ssh_key[0].id : null
   user_data = templatefile(
-    "${path.module}/../shared/nomad-scripts/nomad-startup.sh.tpl",
+    "${path.module}/template/nomad-startup.sh.tpl",
     {
-      cloud_provider        = "AWS"
       nomad_server_endpoint = var.server_endpoint
       client_tls_cert       = var.enable_mtls ? module.nomad_tls[0].nomad_client_cert : ""
       client_tls_key        = var.enable_mtls ? module.nomad_tls[0].nomad_client_key : ""

--- a/nomad-aws/template/nomad-startup.sh.tpl
+++ b/nomad-aws/template/nomad-startup.sh.tpl
@@ -1,8 +1,5 @@
 #!/bin/bash
 
-# One of 'AWS' or 'GCP'. Value passed into template
-export CLOUD_PROVIDER=${cloud_provider}
-
 PRIVATE_IP="$(hostname --ip-address)"
 export PRIVATE_IP
 


### PR DESCRIPTION
:gear: **Issue**

We've attempted to keep a somewhat general nomad init script, but the details of even GCP versus AWS cause it to be pretty branch heavy. As we think about supporting more cloud providers, and perhaps even on-prem situations like vSphere, this will get more branch-y. 

:white_check_mark: **Fix**

Just make the nomad script private to the AWS specific module and don't make such attempts at being general.

:question: **Tests**

<!-- Enumerate what you tested here. We 💖 screenshots and issue specific tests!-->

- [x] Passes _reality check_
- [x] Passes `terraform init` and `terraform validate` (ran outside of local directory to check working directory independence)
