### PR TITLE
reduce user-data size for nomad-aws module

### DIFF
--- a/nomad-aws/versions.tf
+++ b/nomad-aws/versions.tf
@@ -4,5 +4,9 @@ terraform {
       version = "~> 3.0"
       source  = "hashicorp/aws"
     }
+    cloudinit = {
+      version = "~> 2.0"
+      source  = "hashicorp/cloudinit"
+    }
   }
 }


### PR DESCRIPTION
:gear: **Issue**

The current iteration of nomad-aws user-data gets really close to the
maximum number of bytes that AWS allows for (it complains at around 21,600
bytes in base64 encoded format).

The use case is if someone forks this module and adds additional
content, they will very quickly hit that limit (which is what happened
to me)

:white_check_mark: **Fix**

The [cloudinit Terraform provider](https://registry.terraform.io/providers/hashicorp/cloudinit/latest/docs/data-sources/cloudinit_config) makes it pretty transparent to compress
and base64 encode user data, it resulted in a size reduction of 50% in
my case.

:question: **Tests**

- [x] Passed _reality check_
