### PR TITLE
Fix/expose volume type

### DIFF
--- a/nomad-aws/README.md
+++ b/nomad-aws/README.md
@@ -73,6 +73,7 @@ There are more examples in the `examples` directory.
 | enable\_mtls | MTLS support for Nomad traffic. Modifying this can be dangerous and is not recommended. | `bool` | `true` | no |
 | instance\_type | AWS Node type for instance. Must be amd64 linux type | `string` | `"t3a.2xlarge"` | no |
 | nodes | Number of nomad client to create | `number` | n/a | yes |
+| volume\_type | The EBS volume type of the nomad nodes. If gp2 is not available in your desired region, switch to gp2 | `string` | gp3 | no |
 | region | AWS Region | `string` | n/a | yes |
 | security\_group\_id | ID for the security group for Nomad clients.<br>See security documentation for recommendations. | `list(string)` | `[]` | no |
 | server\_endpoint | Domain and port of RPC service of Nomad control plane (e.g example.com:4647) | `string` | n/a | yes |

--- a/nomad-aws/README.md
+++ b/nomad-aws/README.md
@@ -73,7 +73,7 @@ There are more examples in the `examples` directory.
 | enable\_mtls | MTLS support for Nomad traffic. Modifying this can be dangerous and is not recommended. | `bool` | `true` | no |
 | instance\_type | AWS Node type for instance. Must be amd64 linux type | `string` | `"t3a.2xlarge"` | no |
 | nodes | Number of nomad client to create | `number` | n/a | yes |
-| volume\_type | The EBS volume type of the nomad nodes. If gp2 is not available in your desired region, switch to gp2 | `string` | gp3 | no |
+| volume\_type | The EBS volume type of the nomad nodes. If gp3 is not available in your desired region, switch to gp2 | `string` | gp3 | no |
 | region | AWS Region | `string` | n/a | yes |
 | security\_group\_id | ID for the security group for Nomad clients.<br>See security documentation for recommendations. | `list(string)` | `[]` | no |
 | server\_endpoint | Domain and port of RPC service of Nomad control plane (e.g example.com:4647) | `string` | n/a | yes |

--- a/nomad-aws/main.tf
+++ b/nomad-aws/main.tf
@@ -69,7 +69,7 @@ resource "aws_instance" "nomad_client" {
   user_data_base64       = data.cloudinit_config.nomad_user_data.rendered
 
   root_block_device {
-    volume_type = "gp3"
+    volume_type = var.volume_type
     volume_size = "100"
   }
 

--- a/nomad-aws/variables.tf
+++ b/nomad-aws/variables.tf
@@ -41,6 +41,12 @@ variable "nodes" {
   description = "Number of nomad client to create"
 }
 
+variable "volume_type" {
+  type        = string
+  description = "The EBS volume type of the node"
+  default     = "gp3"
+}
+
 variable "instance_type" {
   type        = string
   description = "AWS Node type for instance. Must be amd64 linux type"

--- a/nomad-aws/variables.tf
+++ b/nomad-aws/variables.tf
@@ -43,7 +43,7 @@ variable "nodes" {
 
 variable "volume_type" {
   type        = string
-  description = "The EBS volume type of the node"
+  description = "The EBS volume type of the node. If gp3 is not available in your desired region, switch to gp2"
   default     = "gp3"
 }
 


### PR DESCRIPTION
:gear: **Issue**

<!-- What's wrong; why the change? A good place to reference the ticket if it exists. -->
The volume type "gp3" isn't currently supported in AWS launch configurations in all regions.
[See here](https://github.com/terraform-aws-modules/terraform-aws-eks/issues/1205) for more info

:white_check_mark: **Fix**

<!-- How did you fix the issue? -->
swapped the hardcoded volume-type for a variable which an operator may update

Notes:
Left the default value as gp3 in case there are any existing clusters with this volume type.
