### PR TITLE
GCP Nomad workers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,12 @@ workflows:
           requires:
             - format
             - shellcheck/check
+      - validate:
+          name: Nomad GCP basic
+          tf_path: nomad-gcp/examples/basic
+          requires:
+           - format
+           - shellcheck/check
 
 executors:
   default:

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ modules that are helpful in hosting CircleCI server 3.0.
 ## Contents
 
 - [AWS Nomad Clients](./nomad-aws/README.md)
-- [GCP Nomad Clients](./nomad-gcp/README.md) (coming soon)
+- [GCP Nomad Clients](./nomad-gcp/README.md)
 
 ## Usage
 

--- a/nomad-gcp/README.md
+++ b/nomad-gcp/README.md
@@ -1,0 +1,91 @@
+# GCP Nomad Clients
+
+This is a simple Terraform module to create Nomad clients for your CircleCI
+server application on Google Cloud Platform.
+
+## Usage
+
+A basic example is as simple as this:
+
+```Terraform
+provider "google-beta" {
+  project = "my-project"
+  region  = "us-east1"
+  zone    = "us-east1-a"
+}
+
+module "nomad" {
+  # We strongly recommend pinning the version using ref=<<release tag>> as is done here
+  source = "git::https://github.com/CircleCI-Public/server-terraform.git?//nomad-aws?ref=3.0.0"
+
+  zone            = "us-east1-a"
+  region          = "us-east1"
+  network         = "default"
+  server_endpoint = "nomad.example.com:4647"
+}
+
+output "module" {
+  value = module.nomad
+}
+```
+
+There are more examples in the `examples` directory.
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| google | ~> 3.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| google | ~> 3.0 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| tls | ./../shared/modules/tls |  |
+
+## Resources
+
+| Name |
+|------|
+| [google_compute_autoscaler](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/compute_autoscaler) |
+| [google_compute_firewall](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/compute_firewall) |
+| [google_compute_image](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/data-sources/compute_image) |
+| [google_compute_instance_group_manager](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/compute_instance_group_manager) |
+| [google_compute_instance_template](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/compute_instance_template) |
+| [google_compute_target_pool](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/compute_target_pool) |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| assign\_public\_ip | Assign public IP | `bool` | `true` | no |
+| autoscaling\_mode | Autoscaler mode. Can be<br>- "ON": Autoscaler will scale up and down to reach cpu target and react to cron schedules<br>- "OFF": Autoscaler will never scale up or down<br>- "ONLY\_UP": Autoscaler will only scale up (default)<br>Warning: jobs may be interrupted on scale down. Only select "ON" if<br>interruptions are acceptible for your use case. | `string` | `"ONLY_UP"` | no |
+| autoscaling\_schedules | Autoscaler scaling schedules. Accepts the same arguments are documented<br>upstream here: https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_autoscaler#scaling_schedules | <pre>list(object({<br>    name                  = string<br>    min_required_replicas = number<br>    schedule              = string<br>    time_zone             = string<br>    duration_sec          = number<br>    disabled              = bool<br>    description           = string<br>  }))</pre> | `[]` | no |
+| blocked\_cidrs | List of CIDR blocks to block access to from inside nomad jobs | `list(string)` | `[]` | no |
+| disk\_size\_gb | Root disk size in GB | `number` | `300` | no |
+| disk\_type | Root disk type. Can be 'pd-standard', 'pd-ssd', 'pd-balanced' or 'local-ssd' | `string` | `"pd-ssd"` | no |
+| machine\_type | Instance type for nomad clients | `string` | `"n2d-standard-8"` | no |
+| max\_replicas | Max number of nomad clients when scaled up | `number` | `4` | no |
+| min\_replicas | Minimum number of nomad clients when scaled down | `number` | `1` | no |
+| network | Network to deploy nomad clients into | `string` | `"default"` | no |
+| preemptible | Whether or not to use preemptible nodes | `bool` | `false` | no |
+| region | GCP region to deploy nomad clients into (e.g us-east1) | `string` | n/a | yes |
+| retry\_with\_ssh\_allowed\_cidr\_blocks | List of source IP CIDR blocks that can use the 'retry with SSH' feature of CircleCI jobs | `list(string)` | <pre>[<br>  "0.0.0.0/0"<br>]</pre> | no |
+| server\_endpoint | Hostname:port of nomad control plane | `string` | n/a | yes |
+| target\_cpu\_utilization | Target CPU utilization to trigger autoscaling | `number` | `0.5` | no |
+| unsafe\_disable\_mtls | Disables mTLS between nomad client and servers. Compromises the authenticity and confidentiality of client-server communication. Should not be set to true in any production setting | `bool` | `false` | no |
+| zone | GCP compute zone to deploy nomad clients into (e.g us-east1-a) | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| nomad\_server\_cert | n/a |
+| nomad\_server\_key | n/a |
+| nomad\_tls\_ca | n/a |

--- a/nomad-gcp/examples/basic/main.tf
+++ b/nomad-gcp/examples/basic/main.tf
@@ -1,0 +1,52 @@
+variable "project" {
+  type    = string
+  default = "nsmith-dev"
+}
+
+variable "region" {
+  type    = string
+  default = "us-central1"
+}
+
+variable "zone" {
+  type    = string
+  default = "us-central1-c"
+}
+
+variable "network" {
+  type    = string
+  default = "default"
+}
+
+variable "server_endpoint" {
+  type    = string
+  default = "nomad.ns.sphereci.com:4647"
+}
+
+provider "google-beta" {
+  project = var.project
+  region  = var.region
+  zone    = var.zone
+}
+
+module "nomad" {
+  source = "./../../"
+
+  zone            = var.zone
+  region          = var.region
+  network         = var.network
+  server_endpoint = var.server_endpoint
+
+  unsafe_disable_mtls    = false
+  assign_public_ip       = true
+  preemptible            = true
+  target_cpu_utilization = 0.50
+
+  blocked_cidrs = [
+    "8.8.8.8/32",
+  ]
+}
+
+output "module" {
+  value = module.nomad
+}

--- a/nomad-gcp/examples/basic/main.tf
+++ b/nomad-gcp/examples/basic/main.tf
@@ -1,16 +1,16 @@
 variable "project" {
   type    = string
-  default = "nsmith-dev"
+  default = "example-project"
 }
 
 variable "region" {
   type    = string
-  default = "us-central1"
+  default = "us-west1"
 }
 
 variable "zone" {
   type    = string
-  default = "us-central1-c"
+  default = "us-west1-a"
 }
 
 variable "network" {
@@ -18,9 +18,14 @@ variable "network" {
   default = "default"
 }
 
+variable "subnetwork" {
+  type    = string
+  default = "default"
+}
+
 variable "server_endpoint" {
   type    = string
-  default = "nomad.ns.sphereci.com:4647"
+  default = "nomad.example.com.com:4647"
 }
 
 provider "google-beta" {
@@ -35,16 +40,13 @@ module "nomad" {
   zone            = var.zone
   region          = var.region
   network         = var.network
+  subnetwork      = var.subnetwork
   server_endpoint = var.server_endpoint
 
   unsafe_disable_mtls    = false
   assign_public_ip       = true
   preemptible            = true
   target_cpu_utilization = 0.50
-
-  blocked_cidrs = [
-    "8.8.8.8/32",
-  ]
 }
 
 output "module" {

--- a/nomad-gcp/main.tf
+++ b/nomad-gcp/main.tf
@@ -66,7 +66,8 @@ resource "google_compute_instance_template" "nomad" {
   )
 
   network_interface {
-    network = var.network
+    network    = var.subnetwork != "" ? null : var.network
+    subnetwork = var.subnetwork != "" ? var.subnetwork : null
 
     dynamic "access_config" {
       # Content doesn't matter. We want a length 1 if true and 0 if false.

--- a/nomad-gcp/output.tf
+++ b/nomad-gcp/output.tf
@@ -1,0 +1,11 @@
+output "nomad_server_cert" {
+  value = var.unsafe_disable_mtls ? "" : module.tls[0].nomad_server_cert
+}
+
+output "nomad_server_key" {
+  value = var.unsafe_disable_mtls ? "" : module.tls[0].nomad_server_key
+}
+
+output "nomad_tls_ca" {
+  value = var.unsafe_disable_mtls ? "" : module.tls[0].nomad_tls_ca
+}

--- a/nomad-gcp/templates/nomad-startup.sh.tpl
+++ b/nomad-gcp/templates/nomad-startup.sh.tpl
@@ -1,0 +1,226 @@
+#!/bin/bash
+
+export DEBIAN_FRONTEND=noninteractive
+
+log() {
+	msg=$1
+	color="\e[1;36m" # Bold, Cyan
+	reset="\e[0m"
+	echo -e "$${color}$${msg}$${reset}"
+}
+
+tune_io_scheduler() {
+	log "Tuning kernel IO scheduler if needed"
+	if [ -f /sys/block/nvme0n1/queue/scheduler ] && grep -q 'mq-deadline' /sys/block/nvme0n1/queue/scheduler
+	then
+		echo 'mq-deadline' > /sys/block/nvme0n1/queue/scheduler
+		echo 'ACTION=="add|change", KERNEL=="nvme0n1", ATTR{queue/scheduler}="mq-deadline"' > /etc/udev/rules.d/99-circleci-io-scheduler.rules
+	update-grub
+	fi
+}
+
+system_update() {
+	log "Updating system"
+	apt-get update && apt-get -y upgrade
+}
+
+install() {
+	package=$1
+	log "Installing $${package}"
+	apt-get install -y "$${package}"
+}
+
+
+add_docker_repo() {
+	apt-get install -y apt-transport-https ca-certificates curl software-properties-common
+	curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
+	add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+	install "linux-image-$(uname -r)"
+	apt-get update
+	
+}
+
+enabled_docker_userns() {
+	# Enabled user namespacing in Docker (root in container != root on host)
+	# Mitigates CVE 2019-5736 
+	[ -f /etc/docker/daemon.json ] || echo '{}' > /etc/docker/daemon.json
+	tmp=$(mktemp)
+	cp /etc/docker/daemon.json /etc/docker/daemon.json.orig
+	jq '.["userns-remap"]="default"' /etc/docker/daemon.json > "$tmp" && mv "$tmp" /etc/docker/daemon.json
+	echo 'export no_proxy="true"' >> /etc/default/docker
+	
+	systemctl restart docker 
+}
+
+configure_circleci() {
+	public_ip="$(curl -H 'Metadata-Flavor: Google' http://169.254.169.254/computeMetadata/v1/instance/network-interfaces/0/access-configs/0/external-ip)"
+	private_ip="$(hostname --ip-address)"
+	if ! (echo $public_ip | grep -qP "^[\d.]+$"); then
+		echo "Setting the IPv4 address below in /etc/circleci/public-ipv4."
+		echo "This address will be used in builds with \"Rebuild with SSH\"."
+		mkdir -p /etc/circleci
+		echo $private_ip | tee /etc/circleci/public-ipv4
+	fi
+	
+}
+
+install_nomad() {
+	log "Installing Nomad"
+	install zip
+	curl -o nomad.zip https://releases.hashicorp.com/nomad/0.11.8/nomad_0.11.8_linux_amd64.zip
+	unzip nomad.zip
+	mv nomad /usr/bin
+}
+	   
+configure_nomad() {
+	log "Installing TLS Certificates"
+	mkdir -p /etc/nomad/ssl
+    chmod 0700 /etc/nomad/ssl
+	cat <<-EOT > /etc/nomad/ssl/cert.pem
+	${client_tls_cert}
+	EOT
+	cat <<-EOT > /etc/nomad/ssl/key.pem
+	${client_tls_key}
+	EOT
+	cat <<-EOT > /etc/nomad/ssl/ca.pem
+	${tls_ca}
+	EOT
+
+	log "Setting nomad configuration"
+	mkdir -p /etc/nomad
+	cat <<-EOT > /etc/nomad/config.hcl
+	log_level = "DEBUG"
+	name = "$(hostname)"
+	data_dir = "/opt/nomad"
+	datacenter = "default"
+	advertise {
+	  http = "$(hostname --ip-address)"
+	  rpc = "$(hostname --ip-address)"
+	  serf = "$(hostname --ip-address)"
+	}
+	client {
+	  enabled = true
+	  # Expecting to have DNS record for nomad server(s)
+	  server_join = {
+	    retry_join = ["${nomad_server_endpoint}"]
+	  }
+	  node_class = "linux-64bit"
+	  options = {"driver.raw_exec.enable" = "1"}
+	}
+	EOT
+
+	if [ "${client_tls_cert}" ]; then
+		cat <<-EOT >> /etc/nomad/config.hcl
+		tls {
+		  http = false
+		  rpc  = true
+		  # This verifies the CN ([role].[region].nomad) in the certificate,
+		  # not the hostname or DNS name of the of the remote party.
+		  # https://learn.hashicorp.com/tutorials/nomad/security-enable-tls?in=nomad/transport-security#node-certificates
+		  verify_server_hostname = true
+		  ca_file	= "/etc/nomad/ssl/ca.pem"
+		  cert_file = "/etc/nomad/ssl/cert.pem"
+		  key_file	= "/etc/nomad/ssl/key.pem"
+		}
+		EOT
+	fi
+
+	log "Writing nomad systemd unit"
+	cat <<-EOT > /etc/systemd/system/nomad.service
+	[Unit]
+	Description="nomad"
+	[Service]
+	Restart=always
+	RestartSec=30
+	TimeoutStartSec=1m
+	ExecStart=/usr/bin/nomad agent -config /etc/nomad/config.hcl
+	[Install]
+	WantedBy=multi-user.target
+	EOT
+	
+	log "Starting up nomad" 
+	systemctl enable --now nomad
+}
+
+create_ci_network() {
+	docker network create \
+	   --label keep \
+	   --driver=bridge \
+	   --opt com.docker.network.bridge.name=ci-privileged \
+	   ci-privileged
+}
+
+setup_docker_gc() {
+	log "setting up Docker garbage collection"
+	cat <<-EOT > /etc/systemd/system/docker-gc.service
+	[Unit]
+	Description=Docker garbage collector
+	[Service]
+	Type=simple
+	Restart=always
+	ExecStart=/etc/docker-gc-start.rc
+	ExecStop=/bin/bash -c "docker rm -f docker-gc || true"
+	[Install]
+	WantedBy=cloud-init.target
+	EOT
+	chown root:root /etc/systemd/system/docker-gc.service
+	chmod 0600 /etc/systemd/system/docker-gc.service
+
+	cat <<-EOT > /etc/docker-gc-start.rc
+	#!/bin/bash
+	set -euo pipefail
+	timeout 1m docker pull circleci/docker-gc:1.0
+	docker rm -f docker-gc || true
+	# Will return exit 0 if volume already exists
+	docker volume create docker-gc --label=keep
+	# --net=host is used to allow the container to talk to the local statsd agent
+	docker run \
+	  --rm \
+	  --interactive \
+	  --name "docker-gc" \
+	  --privileged \
+	  --net=host \
+	  --userns=host \
+	  --volume /var/run/docker.sock:/var/run/docker.sock \
+	  --volume /var/lib/docker:/var/lib/docker:ro \
+	  --volume docker-gc:/state \
+	  "circleci/docker-gc:1.0" \
+	  -threshold "1000 KB"
+	EOT
+	chmod 0700 /etc/docker-gc-start.rc
+
+	systemctl enable --now docker-gc
+}
+
+tune_io_scheduler
+system_update
+add_docker_repo
+
+install ntp
+install docker-ce=5:19.03.13~3-0~ubuntu-focal 
+install docker-ce-cli=5:19.03.13~3-0~ubuntu-focal
+install jq
+
+enabled_docker_userns
+configure_circleci
+install_nomad
+configure_nomad
+
+create_ci_network
+setup_docker_gc
+
+echo "--------------------------------------"
+echo "	Securing Docker network interfaces"
+echo "--------------------------------------"
+docker_chain="DOCKER-USER"
+# Blocking meta-data endpoint access
+/sbin/iptables --wait --insert $docker_chain 1 -i br+ --destination 169.254.169.254/32 -p tcp --dport 53 --jump RETURN # Allow DNS queries
+/sbin/iptables --wait --insert $docker_chain 2 -i br+ --destination 169.254.169.254/32 -p udp --dport 53 --jump RETURN # Allow DNS queries
+/sbin/iptables --wait --insert $docker_chain 3 -i docker+ --destination "169.254.0.0/16" --jump DROP
+/sbin/iptables --wait --insert $docker_chain 4 -i br-+ --destination "169.254.0.0/16" --jump DROP
+
+# Blocking internal cluster resources
+%{ for cidr_block in blocked_cidrs ~}
+/sbin/iptables --wait --insert $docker_chain 5 -i docker+ --destination "${cidr_block}" --jump DROP
+/sbin/iptables --wait --insert $docker_chain 5 -i br+ --destination "${cidr_block}" --jump DROP
+%{ endfor ~}

--- a/nomad-gcp/variables.tf
+++ b/nomad-gcp/variables.tf
@@ -14,6 +14,12 @@ variable "network" {
   description = "Network to deploy nomad clients into"
 }
 
+variable "subnetwork" {
+  type        = string
+  default     = ""
+  description = "Subnetwork to deploy nomad clients into. NB. This is required if using custom subnets"
+}
+
 variable "unsafe_disable_mtls" {
   type        = bool
   default     = false

--- a/nomad-gcp/variables.tf
+++ b/nomad-gcp/variables.tf
@@ -1,0 +1,116 @@
+variable "zone" {
+  type        = string
+  description = "GCP compute zone to deploy nomad clients into (e.g us-east1-a)"
+}
+
+variable "region" {
+  type        = string
+  description = "GCP region to deploy nomad clients into (e.g us-east1)"
+}
+
+variable "network" {
+  type        = string
+  default     = "default"
+  description = "Network to deploy nomad clients into"
+}
+
+variable "unsafe_disable_mtls" {
+  type        = bool
+  default     = false
+  description = "Disables mTLS between nomad client and servers. Compromises the authenticity and confidentiality of client-server communication. Should not be set to true in any production setting"
+}
+
+variable "retry_with_ssh_allowed_cidr_blocks" {
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
+  description = "List of source IP CIDR blocks that can use the 'retry with SSH' feature of CircleCI jobs"
+}
+
+variable "server_endpoint" {
+  type        = string
+  description = "Hostname:port of nomad control plane"
+}
+
+variable "blocked_cidrs" {
+  type        = list(string)
+  default     = []
+  description = "List of CIDR blocks to block access to from inside nomad jobs"
+}
+
+variable "min_replicas" {
+  type        = number
+  default     = 1
+  description = "Minimum number of nomad clients when scaled down"
+}
+
+variable "max_replicas" {
+  type        = number
+  default     = 4
+  description = "Max number of nomad clients when scaled up"
+}
+
+variable "autoscaling_mode" {
+  type        = string
+  default     = "ONLY_UP"
+  description = <<-EOF
+    Autoscaler mode. Can be
+    - "ON": Autoscaler will scale up and down to reach cpu target and react to cron schedules
+    - "OFF": Autoscaler will never scale up or down
+    - "ONLY_UP": Autoscaler will only scale up (default)
+    Warning: jobs may be interrupted on scale down. Only select "ON" if
+    interruptions are acceptible for your use case.
+  EOF
+}
+
+variable "autoscaling_schedules" {
+  type = list(object({
+    name                  = string
+    min_required_replicas = number
+    schedule              = string
+    time_zone             = string
+    duration_sec          = number
+    disabled              = bool
+    description           = string
+  }))
+  default     = []
+  description = <<-EOF
+    Autoscaler scaling schedules. Accepts the same arguments are documented
+    upstream here: https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_autoscaler#scaling_schedules
+  EOF
+}
+
+variable "target_cpu_utilization" {
+  type        = number
+  default     = 0.5
+  description = "Target CPU utilization to trigger autoscaling"
+}
+
+variable "machine_type" {
+  type        = string
+  default     = "n2d-standard-8" # AMD Rome | 8vCPU | 32GiB
+  description = "Instance type for nomad clients"
+}
+
+variable "assign_public_ip" {
+  type        = bool
+  default     = true
+  description = "Assign public IP"
+}
+
+variable "preemptible" {
+  type        = bool
+  default     = false
+  description = "Whether or not to use preemptible nodes"
+}
+
+variable "disk_type" {
+  type        = string
+  default     = "pd-ssd"
+  description = "Root disk type. Can be 'pd-standard', 'pd-ssd', 'pd-balanced' or 'local-ssd'"
+}
+
+variable "disk_size_gb" {
+  type        = number
+  default     = 300
+  description = "Root disk size in GB"
+}

--- a/nomad-gcp/versions.tf
+++ b/nomad-gcp/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_providers {
+    google = {
+      version = "~> 3.0"
+      // NOTE: This can be set to hashicorp/google once scaling_schedules are
+      // out of beta on google_compute_autoscaler resources
+      source = "hashicorp/google-beta"
+    }
+  }
+}


### PR DESCRIPTION
:gear: **Issue**

We want to support GCP nomad workers for GA and we currently don't.

:white_check_mark: **Fix**

Creates a module for creating nomad workers in GCP. Feature list
- CPU based autoscaling with customizable target utilization
- Cron scheduled scaling
- Preemptible nodes can be enabled (saves 💰 by using short lived nodes)
- Instance type and disk type modifiable
- Can enumerate allowed IP source addresses for "retry with ssh"
- Can enumarate destination IP addresses to block from nomad jobs
- mTLS
- Option to not assign public IP

:question: **Tests**

The follow settings all pass reality check:

- [x] mTLS enabled or disabled
- [x] Preemptible nodes enabled or disabled
- [x] Public IP address enabled or disabled
- [x] Default autosubnetted network
- [x] Custom subnetted network

Additional tested features

- [x] Retry with SSH works if source IP in `retry_with_ssh_allowed_cidr_blocks` and vice versa
- [x] Can set target cpu utilization and when surpassed the workers scale up
- [x] Workers also scale back down when load is removed
- [x] All 4 disk types (pd-ssd, pd-balanced, pd-standard and local-ssd) have been verified to work
- [x] Verify that cloud metadata endpoint isn't accessible from a job
- [x] Verify that when a CIDR block is added to `blocked_cidrs` it can't be reached from inside a CI job
- [x] Verify that changes to min_replicas and max_replicas work