### PR TITLE
Updates to make nomad-aws a reusable module.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ module "my-aws-nomad-clients" {
 ## Compatibility
 
 The modules in this repository are meant to be used with [terraform
-v0.14.2](https://releases.hashicorp.com/terraform/0.14.2/)
+v0.14.2](https://releases.hashicorp.com/terraform/0.14.2/) and above.
 
 ## How to contribute
 

--- a/nomad-aws/README.md
+++ b/nomad-aws/README.md
@@ -9,11 +9,11 @@ A basic example is as simple as this:
 
 ```Terraform
 terraform {
-  required_version = ">= 0.14.0"
+  required_version = "~>0.14.2"
   required_providers {
     aws = {
       source = "hashicorp/aws"
-      version = ">=3.0.0"
+      version = "~>3.0"
     }
   }
 }
@@ -30,7 +30,6 @@ module "nomad_clients" {
   # Number of nomad clients to run
   nodes = 4
 
-  region = "<< Region you want to run nomad clients in >>"
   subnet = "<< ID of subnet you want to run nomad clients in >>"
   vpc_id = "<< ID of VPC you want to run nomad client in >>"
 
@@ -56,12 +55,6 @@ output "nomad_ca" {
 ```
 
 There are more examples in the `examples` directory.
-
-## Requirements
-
-| Name | Version |
-|------|---------|
-| aws | ~> 3.0 |
 
 ## Inputs
 

--- a/nomad-aws/examples/basic/main.tf
+++ b/nomad-aws/examples/basic/main.tf
@@ -1,9 +1,9 @@
 terraform {
-  required_version = ">= 0.14.2"
+  required_version = "~>0.14.2"
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">=3.0.0"
+      version = "~>3.0"
     }
   }
 }
@@ -33,7 +33,6 @@ module "nomad-aws" {
   # Number of nomad clients to run
   nodes = 4
 
-  region = "us-east-1"
   subnet = module.vpc.public_subnets[0]
   vpc_id = module.vpc.vpc_id
 

--- a/nomad-aws/main.tf
+++ b/nomad-aws/main.tf
@@ -1,7 +1,3 @@
-provider "aws" {
-  region = var.region
-}
-
 resource "random_string" "key_suffix" {
   length  = 8
   special = false

--- a/nomad-aws/variables.tf
+++ b/nomad-aws/variables.tf
@@ -1,8 +1,3 @@
-variable "region" {
-  type        = string
-  description = "AWS Region"
-}
-
 variable "subnet" {
   type        = string
   description = "Subnet ID"

--- a/nomad-aws/versions.tf
+++ b/nomad-aws/versions.tf
@@ -1,11 +1,11 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 3.0"
+      version = ">=3.0"
       source  = "hashicorp/aws"
     }
     cloudinit = {
-      version = "~> 2.0"
+      version = ">=2.0"
       source  = "hashicorp/cloudinit"
     }
   }


### PR DESCRIPTION
This makes two changes to follow Terraform best practices for reusable modules:

* It removes the provider definition from the module: https://www.terraform.io/docs/language/modules/develop/providers.html
* It changes the way that version constraints are specified: https://www.terraform.io/docs/language/expressions/version-constraints.html