### PR TITLE
(maint) Add name var for gcp nomad clients

### DIFF
--- a/nomad-gcp/README.md
+++ b/nomad-gcp/README.md
@@ -73,6 +73,7 @@ There are more examples in the `examples` directory.
 | machine\_type | Instance type for nomad clients | `string` | `"n2d-standard-8"` | no |
 | max\_replicas | Max number of nomad clients when scaled up | `number` | `4` | no |
 | min\_replicas | Minimum number of nomad clients when scaled down | `number` | `1` | no |
+| name | VM instance name for nomad client | `string` | `"nomad"` | no |
 | network | Network to deploy nomad clients into | `string` | `"default"` | no |
 | preemptible | Whether or not to use preemptible nodes | `bool` | `false` | no |
 | region | GCP region to deploy nomad clients into (e.g us-east1) | `string` | n/a | yes |

--- a/nomad-gcp/main.tf
+++ b/nomad-gcp/main.tf
@@ -6,7 +6,7 @@ module "tls" {
 }
 
 resource "google_compute_autoscaler" "nomad" {
-  name   = "nomad"
+  name   = var.name
   zone   = var.zone
   target = google_compute_instance_group_manager.nomad.id
 
@@ -96,12 +96,12 @@ resource "google_compute_instance_template" "nomad" {
 }
 
 resource "google_compute_target_pool" "nomad" {
-  name   = "nomad"
+  name   = var.name
   region = var.region
 }
 
 resource "google_compute_instance_group_manager" "nomad" {
-  name = "nomad"
+  name = var.name
   zone = var.zone
 
   version {
@@ -120,7 +120,7 @@ data "google_compute_image" "ubuntu_2004" {
 
 
 resource "google_compute_firewall" "default" {
-  name    = "allow-retry-with-ssh-circleci-server"
+  name    = "allow-retry-with-ssh-circleci-server-${var.name}"
   network = var.network
 
   allow {

--- a/nomad-gcp/variables.tf
+++ b/nomad-gcp/variables.tf
@@ -120,3 +120,9 @@ variable "disk_size_gb" {
   default     = 300
   description = "Root disk size in GB"
 }
+
+variable "name" {
+  type        = string
+  default     = "nomad"
+  description = "VM instance name for nomad client"
+}


### PR DESCRIPTION
:gear: **Issue**

Unable to create multiple nomad clients pointing to the same network. This resulted in a firewall creation collision.

:white_check_mark: **Fix**

Added a var for the nomad client creation. Defaults to `nomad` still.
