### PR TITLE
[SERVER-1023] Enable telemetry on Nomad client

### DIFF
--- a/nomad-aws/template/nomad-startup.sh.tpl
+++ b/nomad-aws/template/nomad-startup.sh.tpl
@@ -111,6 +111,13 @@ client {
     node_class = "linux-64bit"
     options = {"driver.raw_exec.enable" = "1"}
 }
+telemetry {
+    collection_interval = "1s"
+    disable_hostname = true
+    prometheus_metrics = true
+    publish_allocation_metrics = true
+    publish_node_metrics = true
+}
 EOT
 
 if [ "${client_tls_cert}" ]; then

--- a/nomad-gcp/templates/nomad-startup.sh.tpl
+++ b/nomad-gcp/templates/nomad-startup.sh.tpl
@@ -107,6 +107,13 @@ configure_nomad() {
 	  node_class = "linux-64bit"
 	  options = {"driver.raw_exec.enable" = "1"}
 	}
+	telemetry {
+	  collection_interval = "1s"
+	  disable_hostname = true
+	  prometheus_metrics = true
+	  publish_allocation_metrics = true
+	  publish_node_metrics = true
+	}
 	EOT
 
 	if [ "${client_tls_cert}" ]; then


### PR DESCRIPTION
:gear: **Issue**
We want to collect nomad metrics for prometheus to scrape. Currently nomad-metrics exposes a custom set of nomad metrics. Enabling telemetry exposes the full list of nomad server metrics and is needed to access client metrics.

:white_check_mark: **Fix**
Enabled Telemetry on nomad clients to match server configs in this PR: https://github.com/circleci/server/pull/319

:question: **Tests**

Validated that nomad metrics appear in prometheus
