### PR TITLE
Fix list function

### DIFF
--- a/nomad-aws/main.tf
+++ b/nomad-aws/main.tf
@@ -29,10 +29,10 @@ module "nomad_tls" {
 locals {
   # Creates the Nomad Security Group(SG) list for the Instances.
   # Will include SSH SG if var.ssh_key is not null.
-  nomad_security_groups = compact(list(
+  nomad_security_groups = compact([
     aws_security_group.nomad_sg.id,
     var.ssh_key != null ? aws_security_group.ssh_sg[0].id : "",
-  ))
+  ])
 }
 
 data "cloudinit_config" "nomad_user_data" {


### PR DESCRIPTION
:gear: **Issue**

When trying to use the module for AWS with Terraform v0.12 or later, you'd get an error like this:
```
Error: Error in function call> │> │ on .terraform/modules/nomad_clients/nomad-aws/main.tf line 36, in locals:> │ 36: nomad_security_groups = compact(list(> │ 37: aws_security_group.nomad_sg.id,> │ 38: var.ssh_key != null ? aws_security_group.ssh_sg[0].id : "",> │ 39: ))> │> │ │ aws_security_group.nomad_sg.id will be known only after apply> │ │ aws_security_group.ssh_sg[0].id will be known only after apply> │ │ var.ssh_key is a string, known only after apply> │> │ Call to function "list" failed: the "list" function was deprecated in Terraform v0.12 and is no longer available; use tolist([ ... ]) syntax to write a literal list.
```

:white_check_mark: **Fix**

Use the suggested `tolist` function instead

:question: **Tests**

- [x] Passed `terraform validate`
- [x] Can successfully create cluster with updated module
