### PR TITLE
updating terraform required version to v0.15.4 or higher

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ executors:
   default:
     resource_class: small
     docker:
-      - image: hashicorp/terraform:0.14.2
+      - image: hashicorp/terraform:0.15.4
 jobs:
   validate:
     executor: default

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ module "my-aws-nomad-clients" {
 ## Compatibility
 
 The modules in this repository are meant to be used with [terraform
-v0.14.2](https://releases.hashicorp.com/terraform/0.14.2/) and above.
+v0.15.4](https://releases.hashicorp.com/terraform/0.15.4/) and above.
 
 ## How to contribute
 

--- a/nomad-aws/README.md
+++ b/nomad-aws/README.md
@@ -9,7 +9,7 @@ A basic example is as simple as this:
 
 ```Terraform
 terraform {
-  required_version = "~>0.14.2"
+  required_version = "~>0.15.4"
   required_providers {
     aws = {
       source = "hashicorp/aws"

--- a/nomad-aws/examples/basic/main.tf
+++ b/nomad-aws/examples/basic/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~>0.14.2"
+  required_version = "~>0.15.2"
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/nomad-aws/output.tf
+++ b/nomad-aws/output.tf
@@ -7,7 +7,7 @@ output "nomad_server_cert" {
 }
 
 output "nomad_server_key" {
-  value = var.enable_mtls ? module.nomad_tls[0].nomad_server_key : ""
+  value = nonsensitive(var.enable_mtls ? module.nomad_tls[0].nomad_server_key : "")
 }
 
 output "nomad_tls_ca" {

--- a/nomad-gcp/output.tf
+++ b/nomad-gcp/output.tf
@@ -3,7 +3,7 @@ output "nomad_server_cert" {
 }
 
 output "nomad_server_key" {
-  value = var.unsafe_disable_mtls ? "" : module.tls[0].nomad_server_key
+  value = nonsensitive(var.unsafe_disable_mtls ? "" : module.tls[0].nomad_server_key)
 }
 
 output "nomad_tls_ca" {

--- a/shared/modules/tls/outputs.tf
+++ b/shared/modules/tls/outputs.tf
@@ -12,6 +12,7 @@ output "nomad_client_cert" {
 
 output "nomad_client_key" {
   value = tls_private_key.nomad_client.private_key_pem
+  sensitive = true
 }
 
 output "nomad_tls_ca" {

--- a/shared/modules/tls/outputs.tf
+++ b/shared/modules/tls/outputs.tf
@@ -11,7 +11,7 @@ output "nomad_client_cert" {
 }
 
 output "nomad_client_key" {
-  value = tls_private_key.nomad_client.private_key_pem
+  value     = tls_private_key.nomad_client.private_key_pem
   sensitive = true
 }
 


### PR DESCRIPTION
:gear: **Issue**

<!-- What's wrong; why the change? A good place to reference the ticket if it exists. -->
Our current terraform scripts require the use of nonsensitive which is only available in v0.15
https://circleci.atlassian.net/browse/SERVER-1164

:white_check_mark: **Fix**

<!-- How did you fix the issue? -->
Changed min terraform version to v0.15.4
Added nonsensitive to nomad tls key output

Related PRs
https://github.com/circleci/server/pull/851
https://github.com/circleci/circleci-docs/pull/5405


:question: **Tests**

<!-- Enumerate what you tested here. We 💖 screenshots and issue specific tests!-->

- [x] terraform plan/apply
