### PR TITLE
Remove RPC ingress rule for nomad SG

### DIFF
--- a/nomad-aws/security_groups.tf
+++ b/nomad-aws/security_groups.tf
@@ -1,15 +1,11 @@
+data "aws_vpc" "current" {
+  id = var.vpc_id
+}
+
 resource "aws_security_group" "nomad_sg" {
   name        = "${var.basename}-nomad_sg"
   description = "SG for CircleCI Server nomad server/client"
   vpc_id      = var.vpc_id
-
-  ingress {
-    description = "Nomad RPC Communication"
-    from_port   = 4647
-    to_port     = 4647
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
 
   ingress {
     description = "Allow CircleCI Retry with SSH Access"

--- a/nomad-aws/security_groups.tf
+++ b/nomad-aws/security_groups.tf
@@ -1,7 +1,3 @@
-data "aws_vpc" "current" {
-  id = var.vpc_id
-}
-
 resource "aws_security_group" "nomad_sg" {
   name        = "${var.basename}-nomad_sg"
   description = "SG for CircleCI Server nomad server/client"


### PR DESCRIPTION
:gear: **Issue**

There was a superfluous ingress rule in the Nomad server ingress rules

:white_check_mark: **Fix**

remove the rule

:question: **Tests**

- [x] Passed _reality check_
