### PR TITLE
bugfix - nonsensitive fails if MTLS is not enabled

### DIFF
--- a/nomad-aws/output.tf
+++ b/nomad-aws/output.tf
@@ -7,7 +7,7 @@ output "nomad_server_cert" {
 }
 
 output "nomad_server_key" {
-  value = nonsensitive(var.enable_mtls ? module.nomad_tls[0].nomad_server_key : "")
+  value = var.enable_mtls ? nonsensitive(module.nomad_tls[0].nomad_server_key) : ""
 }
 
 output "nomad_tls_ca" {

--- a/nomad-gcp/output.tf
+++ b/nomad-gcp/output.tf
@@ -3,7 +3,7 @@ output "nomad_server_cert" {
 }
 
 output "nomad_server_key" {
-  value = nonsensitive(var.unsafe_disable_mtls ? "" : module.tls[0].nomad_server_key)
+  value = var.unsafe_disable_mtls ? "" : nonsensitive(module.tls[0].nomad_server_key)
 }
 
 output "nomad_tls_ca" {


### PR DESCRIPTION
:gear: **Issue**

<!-- What's wrong; why the change? A good place to reference the ticket if it exists. -->

if mtls is disabled, terraform will fail. the nomad key output will be black which doesn't need to the `nonsensitive` function

:white_check_mark: **Fix**

<!-- How did you fix the issue? -->

`nonsensitive` is only used if mtls is enabled

:question: **Tests**

<!-- Enumerate what you tested here. We 💖 screenshots and issue specific tests!-->

- [x] Deployed nomad without mtls
