### PR TITLE
[SERVER-1177] add details on how to choose an instance size

### DIFF
--- a/nomad-aws/README.md
+++ b/nomad-aws/README.md
@@ -64,7 +64,7 @@ There are more examples in the `examples` directory.
 | blocked\_cidrs | List of CIDR blocks to block access to from within jobs, e.g. your K8s nodes.<br>You won't want to block access to external VMs here.<br>It's okay when your dns\_server is within a blocked CIDR block, you can use var.dns\_server to create an exemption. | `list(string)` | n/a | yes |
 | dns\_server | If the IP address of your VPC DNS server is within one of the blocked CIDR blocks you can create an exemption by entering the IP address for it here | `string` | n/a | yes |
 | enable\_mtls | MTLS support for Nomad traffic. Modifying this can be dangerous and is not recommended. | `bool` | `true` | no |
-| instance\_type | AWS Node type for instance. Must be amd64 linux type | `string` | `"t3a.2xlarge"` | no |
+| instance\_type | AWS Node type for instance. Must be amd64 linux type.  The instance type must be large enough to fit the [resource classes](https://circleci.com/docs/2.0/executor-types/#available-docker-resource-classes) required.  Choosing smaller instance types is an opportunity for cost savings. | `string` | `"t3a.2xlarge"` | no |
 | nodes | Number of nomad client to create | `number` | n/a | yes |
 | volume\_type | The EBS volume type of the nomad nodes. If gp3 is not available in your desired region, switch to gp2 | `string` | gp3 | no |
 | region | AWS Region | `string` | n/a | yes |

--- a/nomad-gcp/README.md
+++ b/nomad-gcp/README.md
@@ -70,7 +70,7 @@ There are more examples in the `examples` directory.
 | blocked\_cidrs | List of CIDR blocks to block access to from inside nomad jobs | `list(string)` | `[]` | no |
 | disk\_size\_gb | Root disk size in GB | `number` | `300` | no |
 | disk\_type | Root disk type. Can be 'pd-standard', 'pd-ssd', 'pd-balanced' or 'local-ssd' | `string` | `"pd-ssd"` | no |
-| machine\_type | Instance type for nomad clients | `string` | `"n2d-standard-8"` | no |
+| machine\_type | Instance type for nomad clients.  The machine type must be large enough to fit the [resource classes](https://circleci.com/docs/2.0/executor-types/#available-docker-resource-classes) required.  Choosing smaller instance types is an opportunity for cost savings. | `string` | `"n2d-standard-8"` | no |
 | max\_replicas | Max number of nomad clients when scaled up | `number` | `4` | no |
 | min\_replicas | Minimum number of nomad clients when scaled down | `number` | `1` | no |
 | name | VM instance name for nomad client | `string` | `"nomad"` | no |


### PR DESCRIPTION
:gear: **Issue**

Customers have no way to make the connection between the docker resource classes and nomad instance types.

:white_check_mark: **Fix**

Reference the docker resource classes in the nomad terraform

:question: **Tests**

docs only

If there is a better way to phrase it, please make the suggestion
