### PR TITLE
SERVER-1289 | nomad-aws: Upgrade docker from 19.03.13 to 20.10.7

### DIFF
--- a/nomad-aws/template/nomad-startup.sh.tpl
+++ b/nomad-aws/template/nomad-startup.sh.tpl
@@ -38,8 +38,8 @@ curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
 add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
 apt-get install -y "linux-image-$UNAME"
 apt-get update
-apt-get -y install docker-ce=5:19.03.13~3-0~ubuntu-focal \
-                   docker-ce-cli=5:19.03.13~3-0~ubuntu-focal
+apt-get -y install docker-ce=5:20.10.7~3-0~ubuntu-focal \
+                   docker-ce-cli=5:20.10.7~3-0~ubuntu-focal
 
 # force docker to use userns-remap to mitigate CVE 2019-5736
 apt-get -y install jq


### PR DESCRIPTION
:gear: **Issue**

Running docker 19.03.13 in nomad clients on AWS, but we'd like to run 20.10.07 to be in sync with cloud

:white_check_mark: **Fix**

Upgrade the docker version

:question: **Tests**

- [x] Passed _reality check_
- [x] Terraform apply worked (old clients removed and new clients running correct docker version)
