### PR TITLE
SERVER-1289 | nomad-gcp: Upgrade docker to 20.10.07

### DIFF
--- a/nomad-gcp/templates/nomad-startup.sh.tpl
+++ b/nomad-gcp/templates/nomad-startup.sh.tpl
@@ -204,8 +204,8 @@ system_update
 add_docker_repo
 
 install ntp
-install docker-ce=5:19.03.13~3-0~ubuntu-focal 
-install docker-ce-cli=5:19.03.13~3-0~ubuntu-focal
+install docker-ce=5:20.10.7~3-0~ubuntu-focal
+install docker-ce-cli=5:20.10.7~3-0~ubuntu-focal
 install jq
 
 enabled_docker_userns


### PR DESCRIPTION
:gear: **Issue**

Running docker 19.03.13 in nomad clients on GCP, but we'd like to run 20.10.07 to be in sync with cloud

:white_check_mark: **Fix**

Upgrade the docker version

:question: **Tests**

- [x] Passed _reality check_
- [x] Terraform apply worked (old clients removed and new clients running correct docker version)