### PR TITLE
[SERVER-1323] adding nomad security group id to output

### DIFF
--- a/nomad-aws/output.tf
+++ b/nomad-aws/output.tf
@@ -13,3 +13,7 @@ output "nomad_server_key" {
 output "nomad_tls_ca" {
   value = var.enable_mtls ? module.nomad_tls[0].nomad_tls_ca : ""
 }
+
+output "nomad_sg_id" {
+  value = aws_security_group.nomad_sg.id
+}


### PR DESCRIPTION
:gear: **Issue**

<!-- What's wrong; why the change? A good place to reference the ticket if it exists. -->
coming from https://circleci.atlassian.net/browse/SERVER-1323 we need to expose the nomad security group id in the module output, allowing users to easily use the id in other security group ingress rules

:white_check_mark: **Fix**

<!-- How did you fix the issue? -->
added security group id to output

:question: **Tests**

<!-- Enumerate what you tested here. We 💖 screenshots and issue specific tests!-->

- [x] Passed _reality check_
