### PR TITLE
(RE-1204) Update nomad client config and create add_server_join var

### DIFF
--- a/nomad-gcp/main.tf
+++ b/nomad-gcp/main.tf
@@ -57,6 +57,7 @@ resource "google_compute_instance_template" "nomad" {
   metadata_startup_script = templatefile(
     "${path.module}/templates/nomad-startup.sh.tpl",
     {
+      add_server_join       = var.add_server_join ? var.add_server_join : ""
       nomad_server_endpoint = var.server_endpoint
       blocked_cidrs         = var.blocked_cidrs
       client_tls_cert       = var.unsafe_disable_mtls ? "" : module.tls[0].nomad_client_cert

--- a/nomad-gcp/templates/nomad-startup.sh.tpl
+++ b/nomad-gcp/templates/nomad-startup.sh.tpl
@@ -100,10 +100,16 @@ configure_nomad() {
 	}
 	client {
 	  enabled = true
-	  # Expecting to have DNS record for nomad server(s)
+	EOT
+	# Expecting to have DNS record for nomad server(s)
+	if [ "${add_server_join}" ]; then
+	cat <<-EOT >> /etc/nomad/config.hcl
 	  server_join = {
 	    retry_join = ["${nomad_server_endpoint}"]
 	  }
+	EOT
+	fi
+	cat <<-EOT >> /etc/nomad/config.hcl
 	  node_class = "linux-64bit"
 	  options = {"driver.raw_exec.enable" = "1"}
 	}

--- a/nomad-gcp/variables.tf
+++ b/nomad-gcp/variables.tf
@@ -126,3 +126,9 @@ variable "name" {
   default     = "nomad"
   description = "VM instance name for nomad client"
 }
+
+variable "add_server_join" {
+  type        = bool
+  default     = true
+  description = "Includes the 'server_join' block when setting up nomad clients. Should be disabled when the nomad server endpoint is not immediately known (eg, for dedicated nomad clients)."
+}


### PR DESCRIPTION
:gear: **Issue**

<!-- What's wrong; why the change? A good place to reference the ticket if it exists. -->
The `integration-workflow` nomad clients are no longer torn down after every workflow run. Since they will be created and left available for future workflow runs and the nomad server URI isn't immediately known. Having the `server_join` block in `config.hcl` leads to configuration issues.

:white_check_mark: **Fix**

<!-- How did you fix the issue? -->
This change creates a new terraform variable `add_server_join`, which defaults to `true`. When set to `false`, it omits the `server_join` block in the nomad client configuration file.

:question: **Tests**

<!-- Enumerate what you tested here. We 💖 screenshots and issue specific tests!-->

- `config.hcl` with `add_server_join` set to false:
![Screen Shot 2021-08-16 at 1 29 12 PM](https://user-images.githubusercontent.com/38337779/129627345-0d6a479b-adf9-4cbf-b43a-17074407b827.png)

- `config.hcl` with `add_server_join` not included in `terraform.tfvars` (defaults to `true`):
![Screen Shot 2021-08-16 at 1 41 30 PM](https://user-images.githubusercontent.com/38337779/129627396-3ea5b066-e882-442f-92df-fcd8a583caa0.png)
