### PR TITLE
Update to the 3.1 release

### DIFF
--- a/nomad-aws/README.md
+++ b/nomad-aws/README.md
@@ -25,7 +25,7 @@ provider "aws" {
 
 module "nomad_clients" {
   # We strongly recommend pinning the version using ref=<<release tag>> as is done here
-  source = "git::https://github.com/CircleCI-Public/server-terraform.git//nomad-aws?ref=3.0.0-RC7"
+  source = "git::https://github.com/CircleCI-Public/server-terraform.git//nomad-aws?ref=3.1.0"
 
   # Number of nomad clients to run
   nodes = 4

--- a/nomad-gcp/README.md
+++ b/nomad-gcp/README.md
@@ -16,7 +16,7 @@ provider "google-beta" {
 
 module "nomad" {
   # We strongly recommend pinning the version using ref=<<release tag>> as is done here
-  source = "git::https://github.com/CircleCI-Public/server-terraform.git?//nomad-aws?ref=3.0.0"
+  source = "git::https://github.com/CircleCI-Public/server-terraform.git//nomad-aws?ref=3.1.0"
 
   zone            = "us-east1-a"
   region          = "us-east1"


### PR DESCRIPTION
:gear: **Issue**

The documented examples had old versions (and even an RC), in addition to a typo in the GCP module.