### PR TITLE
Point GCP docs to the GCP module

### DIFF
--- a/nomad-gcp/README.md
+++ b/nomad-gcp/README.md
@@ -16,7 +16,7 @@ provider "google-beta" {
 
 module "nomad" {
   # We strongly recommend pinning the version using ref=<<release tag>> as is done here
-  source = "git::https://github.com/CircleCI-Public/server-terraform.git//nomad-aws?ref=3.1.0"
+  source = "git::https://github.com/CircleCI-Public/server-terraform.git//nomad-gcp?ref=3.1.0"
 
   zone            = "us-east1-a"
   region          = "us-east1"


### PR DESCRIPTION
:gear: **Issue**

We have a typo that is pointing the GCP docs to the AWS module, which just yields errors.

:white_check_mark: **Fix**

Slight tweak in the README to use the GCP module.

:question: **Tests**

<!-- Enumerate what you tested here. We 💖 screenshots and issue specific tests!-->

- [ ] Passed _reality check_
