### PR TITLE
changing default instance types to intel-based

### DIFF
--- a/nomad-aws/variables.tf
+++ b/nomad-aws/variables.tf
@@ -51,7 +51,7 @@ variable "volume_type" {
 
 variable "instance_type" {
   type        = string
-  description = "AWS Node type for instance. Must be amd64 linux type"
+  description = "AWS Node type for instance. Must be Intel linux type"
   default     = "t3.2xlarge"
 }
 

--- a/nomad-gcp/variables.tf
+++ b/nomad-gcp/variables.tf
@@ -93,7 +93,7 @@ variable "target_cpu_utilization" {
 
 variable "machine_type" {
   type        = string
-  default     = "n2-standard-8" # AMD Rome | 8vCPU | 32GiB
+  default     = "n2-standard-8" # Intel | 8vCPU | 32GiB
   description = "Instance type for nomad clients"
 }
 


### PR DESCRIPTION
:gear: **Issue**

<!-- What's wrong; why the change? A good place to reference the ticket if it exists. -->
Our current default nomad instance types run on AMD CPUs and our build-agent is optimized for Intel

:white_check_mark: **Fix**

<!-- How did you fix the issue? -->
Now using equivalent Intel Machines

:question: **Tests**

<!-- Enumerate what you tested here. We 💖 screenshots and issue specific tests!-->

- [x] Passed _reality check_
