### PR TITLE
GovCloud support

### DIFF
--- a/nomad-aws/main.tf
+++ b/nomad-aws/main.tf
@@ -17,7 +17,7 @@ data "aws_ami" "ubuntu_focal" {
     values = ["ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*"]
   }
 
-  owners = ["099720109477"]
+  owners = ["099720109477", "513442679011"]
 }
 
 module "nomad_tls" {


### PR DESCRIPTION
SERVER-1435

We need to include the owner ID for Canonical's GovCloud account. This
small tweak allows the Terraform to run as expected in GovCloud.