### PR TITLE
[server-1538] adding instructions for setting network and subnetwork when using a shared vpc

### DIFF
--- a/nomad-gcp/README.md
+++ b/nomad-gcp/README.md
@@ -74,7 +74,8 @@ There are more examples in the `examples` directory.
 | max\_replicas | Max number of nomad clients when scaled up | `number` | `4` | no |
 | min\_replicas | Minimum number of nomad clients when scaled down | `number` | `1` | no |
 | name | VM instance name for nomad client | `string` | `"nomad"` | no |
-| network | Network to deploy nomad clients into | `string` | `"default"` | no |
+| network | Network to deploy nomad clients into. If you are using a shared vpc, provide the network endpoint rather than the name | `string` | `"default"` | no |
+| subnetwork | Subnetwork to deploy nomad clients into. NB. This is required if using custom subnets or a shared vpc. If you are using a shared vpc, provide the subnetwork endpoint rather than the name | `string` | `""` | for custom subnets and shared vpcs |
 | preemptible | Whether or not to use preemptible nodes | `bool` | `false` | no |
 | region | GCP region to deploy nomad clients into (e.g us-east1) | `string` | n/a | yes |
 | retry\_with\_ssh\_allowed\_cidr\_blocks | List of source IP CIDR blocks that can use the 'retry with SSH' feature of CircleCI jobs | `list(string)` | <pre>[<br>  "0.0.0.0/0"<br>]</pre> | no |

--- a/nomad-gcp/README.md
+++ b/nomad-gcp/README.md
@@ -75,7 +75,7 @@ There are more examples in the `examples` directory.
 | min\_replicas | Minimum number of nomad clients when scaled down | `number` | `1` | no |
 | name | VM instance name for nomad client | `string` | `"nomad"` | no |
 | network | Network to deploy nomad clients into. If you are using a shared vpc, provide the network endpoint rather than the name | `string` | `"default"` | no |
-| subnetwork | Subnetwork to deploy nomad clients into. NB. This is required if using custom subnets or a shared vpc. If you are using a shared vpc, provide the subnetwork endpoint rather than the name | `string` | `""` | for custom subnets and shared vpcs |
+| subnetwork | Subnetwork to deploy nomad clients into. This is required if using custom subnets or a shared vpc. If you are using a shared vpc, provide the subnetwork endpoint rather than the name | `string` | `""` | for custom subnets and shared vpcs |
 | preemptible | Whether or not to use preemptible nodes | `bool` | `false` | no |
 | region | GCP region to deploy nomad clients into (e.g us-east1) | `string` | n/a | yes |
 | retry\_with\_ssh\_allowed\_cidr\_blocks | List of source IP CIDR blocks that can use the 'retry with SSH' feature of CircleCI jobs | `list(string)` | <pre>[<br>  "0.0.0.0/0"<br>]</pre> | no |

--- a/nomad-gcp/examples/basic/main.tf
+++ b/nomad-gcp/examples/basic/main.tf
@@ -16,11 +16,15 @@ variable "zone" {
 variable "network" {
   type    = string
   default = "default"
+  # if you are using a shared vpc, provide the network endpoint rather than the name. eg:
+  # default = "https://www.googleapis.com/compute/v1/projects/<your-project>/global/networks/default"
 }
 
 variable "subnetwork" {
   type    = string
   default = "default"
+  # if you are using a shared vpc, provide the network endpoint rather than the name. eg:
+  # default = "https://www.googleapis.com/compute/v1/projects/<your-project>/regions/<your-region>/subnetworks/default"
 }
 
 variable "server_endpoint" {


### PR DESCRIPTION
:gear: **[Issue](https://circleci.atlassian.net/browse/SERVER-1538)**

<!-- What's wrong; why the change? A good place to reference the ticket if it exists. -->
We support deploying nomad clients in a shared vpc, but have not documented this

:white_check_mark: **Fix**

<!-- How did you fix the issue? -->
This PR updates our docs and examples

:question: **Tests**

<!-- Enumerate what you tested here. We 💖 screenshots and issue specific tests!-->

- [ ] Passed _reality check_
