### PR TITLE
No jira/update module versions in readme

### DIFF
--- a/nomad-aws/README.md
+++ b/nomad-aws/README.md
@@ -25,7 +25,7 @@ provider "aws" {
 
 module "nomad_clients" {
   # We strongly recommend pinning the version using ref=<<release tag>> as is done here
-  source = "git::https://github.com/CircleCI-Public/server-terraform.git//nomad-aws?ref=3.1.0"
+  source = "git::https://github.com/CircleCI-Public/server-terraform.git//nomad-aws?ref=3.2.0"
 
   # Number of nomad clients to run
   nodes = 4

--- a/nomad-gcp/README.md
+++ b/nomad-gcp/README.md
@@ -16,7 +16,7 @@ provider "google-beta" {
 
 module "nomad" {
   # We strongly recommend pinning the version using ref=<<release tag>> as is done here
-  source = "git::https://github.com/CircleCI-Public/server-terraform.git//nomad-gcp?ref=3.1.0"
+  source = "git::https://github.com/CircleCI-Public/server-terraform.git//nomad-gcp?ref=3.2.0"
 
   zone            = "us-east1-a"
   region          = "us-east1"


### PR DESCRIPTION
Our examples in the readme's point to 3.1.0 however the latest release is 3.2.0
