### PR TITLE
nomad-aws now uses the templatefile function

### DIFF
--- a/nomad-aws/nomad-autoscaler.tf
+++ b/nomad-aws/nomad-autoscaler.tf
@@ -1,13 +1,3 @@
-# Only create a nomad aws user if oidc_arn is empty map {}
-data "template_file" "nomad_asg_policy" {
-  count = var.nomad_auto_scaler ? 1 : 0
-  template = file("${path.module}/template/nomad_asg_policy.tpl")
-
-  vars = {
-    "ASG_ARN" = aws_autoscaling_group.clients_asg.arn
-  }
-}
-
 resource "aws_iam_user" "nomad_asg_user" {
   count = local.autoscaler_type == "user" ? 1 : 0
 
@@ -25,32 +15,27 @@ resource "aws_iam_user_policy" "nomad_asg_user" {
 
   name   = "${var.basename}-nomad-asg-user-policy"
   user   = aws_iam_user.nomad_asg_user[0].name
-  policy = data.template_file.nomad_asg_policy[0].rendered
+  policy = templatefile("${path.module}/template/nomad_asg_policy.tpl", {
+    "ASG_ARN" = aws_autoscaling_group.clients_asg.arn
+  })
 }
 
-
-# Only create a nomad aws role if length of oidc_arn > 0
-data "template_file" "nomad_role_trust_policy" {
-  count = local.autoscaler_type == "role" ? 1 : 0
-
-  template                = file("${path.module}/template/nomad_irsa_trust_policy.tpl")
-  vars                    = {
-    OIDC_PRINCIPAL_ID     = lookup(var.enable_irsa, "oidc_principal_id", "")
-    OIDC_EKS_VARIABLE     = lookup(var.enable_irsa, "oidc_eks_variable", "")
-    K8S_SERVICE_ACCOUNT   = lookup(var.enable_irsa, "k8s_service_account", "")
-  }
-
-}
 
 resource "aws_iam_role" "nomad_role" {
   count = local.autoscaler_type == "role" ? 1 : 0
 
   name                    = "${var.basename}-circleci-nomad-autoscaler-irsa-role"
-  assume_role_policy      =   data.template_file.nomad_role_trust_policy[0].rendered
+  assume_role_policy      = templatefile("${path.module}/template/nomad_irsa_trust_policy.tpl", {
+                              OIDC_PRINCIPAL_ID     = lookup(var.enable_irsa, "oidc_principal_id", "")
+                              OIDC_EKS_VARIABLE     = lookup(var.enable_irsa, "oidc_eks_variable", "")
+                              K8S_SERVICE_ACCOUNT   = lookup(var.enable_irsa, "k8s_service_account", "")
+                            })
 
   inline_policy {
                 name      = "${var.basename}-circleci-nomad-autoscaler-role-policy"
-                policy    = data.template_file.nomad_asg_policy[0].rendered
+                policy    = templatefile("${path.module}/template/nomad_asg_policy.tpl", {
+                              "ASG_ARN" = aws_autoscaling_group.clients_asg.arn
+                            })
   }
   tags                    = local.tags
 }


### PR DESCRIPTION
:gear: **Issue**

<!-- What's wrong; why the change? A good place to reference the ticket if it exists. -->
resolves: https://github.com/CircleCI-Public/server-terraform/issues/132
related ticket: https://circleci.atlassian.net/browse/SERVER-1656

:white_check_mark: **Fix**

<!-- How did you fix the issue? -->
replaced `template_file` data source with `templatefile` function

:question: **Tests**

<!-- Enumerate what you tested here. We 💖 screenshots and issue specific tests!-->

- [x] installed nomad without template module
