### PR TITLE
Enable to associate instance profile to nomad client instance on AWS

### DIFF
--- a/nomad-aws/README.md
+++ b/nomad-aws/README.md
@@ -74,6 +74,7 @@ There are more examples in the `examples` directory.
 | max_nodes | Maximum number of nomad client to create when scaling. Should always be greater than or equal to the node count | `number` | 5 | no |
 | nodes | Number of nomad client to create | `number` | n/a | yes |
 | nomad_auto_scaler | If true, terraform will generate an IAM user to be used by nomad-autoscaler in CircleCI Server. The keys will be available in terraform's output | `bool` | false | no |
+| role_name | Name of the role to add to the instance profile | `string` | `null` | no |
 | volume\_type | The EBS volume type of the nomad nodes. If gp3 is not available in your desired region, switch to gp2 | `string` | `gp3` | no |
 | security\_group\_id | ID for the security group for Nomad clients.<br>See security documentation for recommendations. | `list(string)` | `[]` | no |
 | server\_endpoint | Domain and port of RPC service of Nomad control plane which is called "Nomad Load Balancer" in KOTs admin (e.g 127.0.0.1:4647) | `string` | n/a | yes |

--- a/nomad-aws/main.tf
+++ b/nomad-aws/main.tf
@@ -55,10 +55,18 @@ data "cloudinit_config" "nomad_user_data" {
   }
 }
 
+resource "aws_iam_instance_profile" "nomad_client_profile" {
+  count = var.role_name != null ? 1 : 0
+  name  = "circleci-nomad-clients-instance-profile"
+  role  = var.role_name
+}
+
 resource "aws_launch_configuration" "nomad_client_lc" {
   instance_type = var.instance_type
   image_id      = data.aws_ami.ubuntu_focal.id
   key_name      = var.ssh_key != null ? aws_key_pair.ssh_key[0].id : null
+
+  iam_instance_profile = var.role_name != null ? aws_iam_instance_profile.nomad_client_profile[0].name : null
 
   root_block_device {
     volume_type = var.volume_type

--- a/nomad-aws/variables.tf
+++ b/nomad-aws/variables.tf
@@ -91,6 +91,12 @@ variable "instance_tags" {
   }
 }
 
+variable "role_name" {
+  type        = string
+  description = "Name of the role to add to the instance profile"
+  default     = null
+}
+
 # Check for IRSA Role (more details)  - https://docs.aws.amazon.com/eks/latest/userguide/create-service-account-iam-policy-and-role.html
 #   enable_irsa  = {
 #                  oidc_principal_id  = "arn:aws:iam::<ACCOUNT_ID>:oidc-provider/oidc.eks.<REGION>.amazonaws.com/id/<OIDC_ID>"


### PR DESCRIPTION
:gear: **Issue**

Currently, an instance profile cannot be associated to instances of nomad clients on AWS. But there are cases when I want to associate an instance profile to the instance. (e.g. connect to the instances by Session Manager)

:white_check_mark: **Fix**

This PR adds an optional parameter `role_name`. If specified, an instance profile with the role is associated to nomad client instances.

:question: **Tests**

<!-- Enumerate what you tested here. We 💖 screenshots and issue specific tests!-->

- [ ] Passed _reality check_
