### PR TITLE
server-1557 | Add Policy binding in nomad autoscaler

### DIFF
--- a/nomad-gcp/README.md
+++ b/nomad-gcp/README.md
@@ -86,6 +86,8 @@ There are more examples in the `examples` directory.
 | unsafe\_disable\_mtls | Disables mTLS between nomad client and servers. Compromises the authenticity and confidentiality of client-server communication. Should not be set to true in any production setting | `bool` | `false` | no |
 | zone | GCP compute zone to deploy nomad clients into (e.g us-east1-a) | `string` | n/a | yes |
 | enable_workload_identity | Enable nomad service account as gcp workload identity | `bool` | `false` | no |
+| project | GCP Project ID | `string` | n/a | Yes, if enable_workload_identity is true |
+| k8s_namespace | k8s namespace where application is installed | `string` | `circleci-server` | Yes, if enable_workload_identity is true |
 
 ## Outputs
 

--- a/nomad-gcp/examples/basic/terraform.tfvars_template
+++ b/nomad-gcp/examples/basic/terraform.tfvars_template
@@ -9,3 +9,4 @@ nomad_auto_scaler           = true
 server_endpoint             = "nomad.exmaple.com:4647"
 enable_workload_identity    = true
 machine_type                = "n2-standard-8"
+k8s_namespace               = "circleci-server" # Yes, if enable_workload_identity is true

--- a/nomad-gcp/nomad-autoscaler.tf
+++ b/nomad-gcp/nomad-autoscaler.tf
@@ -23,6 +23,15 @@ resource "google_project_iam_member" "nomad_as_work_identity" {
   member = "serviceAccount:${google_service_account.nomad_as_service_account[0].email}"
 }
 
+resource "google_service_account_iam_binding" "nomad_as_work_identity_k8s" {
+  count              = var.nomad_auto_scaler && var.enable_workload_identity ? 1 : 0
+  service_account_id = google_service_account.nomad_as_service_account[0].name
+  role               = "roles/iam.workloadIdentityUser"
+  members = [
+    "serviceAccount:${var.project}.svc.id.goog[${var.k8s_namespace}/nomad-autoscaler]",
+  ]
+}
+
 resource "google_service_account_key" "nomad-as-key" {
   count              = var.nomad_auto_scaler && !var.enable_workload_identity ? 1 : 0
   service_account_id = google_service_account.nomad_as_service_account[0].name

--- a/nomad-gcp/variables.tf
+++ b/nomad-gcp/variables.tf
@@ -142,5 +142,16 @@ variable "add_server_join" {
 variable "enable_workload_identity" {
   type        = bool
   default     = false
-  description = "If true, Workload Identity will be used rather than static credentials'"
+  description = "If true, Workload Identity will be used rather than static credentials"
+}
+
+variable "k8s_namespace" {
+  type        = string
+  default     = "circleci-server"
+  description = "If enable_workload_identity is true, provide application k8s namespace"
+}
+
+variable "project" {
+  type        = string
+  description = "GCP Project ID"
 }


### PR DESCRIPTION

:gear: **Issue**

Enabling Workload identity for k8s service account

:white_check_mark: **Fix**

Added Policy binding between GCP IAM service account and k8s service account

:question: **Tests**

<!-- Enumerate what you tested here. We 💖 screenshots and issue specific tests!-->

- [ ] Passed _reality check_
