### PR TITLE
mark nomad tf output as sensitive

### DIFF
--- a/nomad-aws/README.md
+++ b/nomad-aws/README.md
@@ -52,7 +52,8 @@ module "nomad_clients" {
 }
 
 output "nomad" {
-  value = module.nomad_clients
+  value     = module.nomad_clients
+  sensitive = true
 }
 ```
 


### PR DESCRIPTION
At least as of terraform v1.1.9, not doing so shows this error:

```
│ Error: Output refers to sensitive values
│
│   on main.tf line 49:
│   49: output "nomad" {
│
│ To reduce the risk of accidentally exporting sensitive data that was intended to be
│ only internal, Terraform requires that any root module output containing sensitive
│ data be explicitly marked as sensitive, to confirm your intent.
│
│ If you do intend to export this data, annotate the output value as sensitive by
│ adding the following argument:
│     sensitive = true
```