### PR TITLE
[SERVER-1779] Switch from using launch configuration to launch templates

### DIFF
--- a/nomad-aws/main.tf
+++ b/nomad-aws/main.tf
@@ -62,21 +62,30 @@ resource "aws_iam_instance_profile" "nomad_client_profile" {
   role  = var.role_name
 }
 
-resource "aws_launch_configuration" "nomad_client_lc" {
+resource "aws_launch_template" "nomad_client" {
+  name_prefix   = "${var.basename}-nomad-clients-"
   instance_type = var.instance_type
   image_id      = data.aws_ami.ubuntu_focal.id
   key_name      = var.ssh_key != null ? aws_key_pair.ssh_key[0].id : null
 
-  iam_instance_profile = var.role_name != null ? aws_iam_instance_profile.nomad_client_profile[0].name : null
+  block_device_mappings {
+    device_name = "/dev/sda1"
 
-  root_block_device {
-    volume_type = var.volume_type
-    volume_size = "100"
+    ebs {
+      volume_type = var.volume_type
+      volume_size = 100
+    }
   }
 
-  security_groups = length(var.security_group_id) != 0 ? var.security_group_id : local.nomad_security_groups
+  dynamic "iam_instance_profile" {
+    for_each = var.role_name != null ? [1] : []
+    content {
+      arn = aws_iam_instance_profile.nomad_client_profile[0].arn
+    }
+  }
 
-  user_data_base64 = data.cloudinit_config.nomad_user_data.rendered
+  vpc_security_group_ids = length(var.security_group_id) != 0 ? var.security_group_id : local.nomad_security_groups
+  user_data              = data.cloudinit_config.nomad_user_data.rendered
 
   lifecycle {
     create_before_destroy = true
@@ -84,13 +93,17 @@ resource "aws_launch_configuration" "nomad_client_lc" {
 }
 
 resource "aws_autoscaling_group" "clients_asg" {
-  name                 = "${var.basename}_circleci_nomad_clients_asg"
-  vpc_zone_identifier  = var.subnet != "" ? [var.subnet] : var.subnets
-  launch_configuration = aws_launch_configuration.nomad_client_lc.name
-  max_size             = var.max_nodes
-  min_size             = var.nomad_auto_scaler ? 1 : 0 # When using nomad-autoscaler, the min nodes can't be less than 1. For more info: https://github.com/hashicorp/nomad-autoscaler/issues/530
-  desired_capacity     = var.nodes
-  force_delete         = true
+  name                = "${var.basename}_circleci_nomad_clients_asg"
+  vpc_zone_identifier = var.subnet != "" ? [var.subnet] : var.subnets
+  max_size            = var.max_nodes
+  min_size            = var.nomad_auto_scaler ? 1 : 0 # When using nomad-autoscaler, the min nodes can't be less than 1. For more info: https://github.com/hashicorp/nomad-autoscaler/issues/530
+  desired_capacity    = var.nodes
+  force_delete        = true
+
+  launch_template {
+    id      = aws_launch_template.nomad_client.id
+    version = var.launch_template_version
+  }
 
   tag {
     key                 = "Name"

--- a/nomad-aws/variables.tf
+++ b/nomad-aws/variables.tf
@@ -98,7 +98,6 @@ variable "instance_tags" {
   type = map(string)
   default = {
     "vendor" = "circleci"
-    "team"   = "server"
   }
 }
 

--- a/nomad-aws/variables.tf
+++ b/nomad-aws/variables.tf
@@ -98,6 +98,7 @@ variable "instance_tags" {
   type = map(string)
   default = {
     "vendor" = "circleci"
+    "team"   = "server"
   }
 }
 

--- a/nomad-aws/variables.tf
+++ b/nomad-aws/variables.tf
@@ -101,6 +101,12 @@ variable "instance_tags" {
   }
 }
 
+variable "launch_template_version" {
+  type        = string
+  description = "Specific version of the instance template"
+  default     = "$Default"
+}
+
 variable "role_name" {
   type        = string
   description = "Name of the role to add to the instance profile"


### PR DESCRIPTION
:gear: **Issue**

[SERVER-1779](https://circleci.atlassian.net/browse/SERVER-1779). Instead of using launch configuration we should switch to launch templates. One advantage is easier versioning.

The `$Default` version will be used unless a specific version of a template is specified in variables.tf. The default version is the first version of the [template unless explicitly changed](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-launch-templates.html). We also have the option to set the version to `$Latest` so that any new instance is on the latest version of the template.

➡️ Applying this change will cause the existing nomad client instances to roll. ⬅️ 

:question: **Tests**

<!-- Enumerate what you tested here. We 💖 screenshots and issue specific tests!-->

- [x] Tested upgrading existing environment
- [x] Passed _reality check_
