### PR TITLE
Default to the latest version of the nomad client launch template

### DIFF
--- a/nomad-aws/variables.tf
+++ b/nomad-aws/variables.tf
@@ -104,7 +104,7 @@ variable "instance_tags" {
 variable "launch_template_version" {
   type        = string
   description = "Specific version of the instance template"
-  default     = "$Default"
+  default     = "$Latest"
 }
 
 variable "role_name" {


### PR DESCRIPTION
:gear: **Issue**

[SERVER-1845](https://circleci.atlassian.net/browse/SERVER-1845). 

:white_check_mark: **Fix**

Currently the `$Default` version of the launch template it used which translates to the **first** version of the template (unless set otherwise). This can create confusion when new instances come up and continue using old settings. The reason is not immediate apparent unless one understands the default [launch configuration](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-launch-templates.html) details. Making sure that the latest template is always used makes more sense.

:question: **Tests**

<!-- Enumerate what you tested here. We 💖 screenshots and issue specific tests!-->

- [x] Passed _reality check_
