### PR TITLE
Server 1922 workload identity docs update

### DIFF
--- a/nomad-gcp/README.md
+++ b/nomad-gcp/README.md
@@ -21,7 +21,7 @@ module "nomad" {
   zone            = "us-east1-a"
   region          = "us-east1"
   network         = "default"
-  server_endpoint = "nomad.example.com:4647"
+  server_endpoint = "example.com:4647"
 }
 
 output "module" {

--- a/nomad-gcp/README.md
+++ b/nomad-gcp/README.md
@@ -86,7 +86,7 @@ There are more examples in the [examples](./examples/) directory.
 | target\_cpu\_utilization | Target CPU utilization to trigger autoscaling | `number` | `0.5` | no |
 | unsafe\_disable\_mtls | Disables mTLS between nomad client and servers. Compromises the authenticity and confidentiality of client-server communication. Should not be set to true in any production setting | `bool` | `false` | no |
 | zone | GCP compute zone to deploy nomad clients into (e.g us-east1-a) | `string` | n/a | yes |
-| enable_workload_identity | Enable nomad service account as gcp workload identity | `bool` | `false` | no |
+| enable_workload_identity | Enable nomad service account as gcp workload identity. Ensure Workload Identities are first enabled on your GKE cluster: https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity | `bool` | `false` | no |
 | k8s_namespace | k8s namespace where application is installed | `string` | `circleci-server` | Yes, if enable_workload_identity is true |
 
 ## Outputs

--- a/nomad-gcp/examples/basic/main.tf
+++ b/nomad-gcp/examples/basic/main.tf
@@ -60,7 +60,7 @@ variable "name" {
 variable "enable_workload_identity" {
   type        = bool
   default     = false
-  description = "If true, Workload Identity will be used rather than static credentials'"
+  description = "If true, Workload Identity will be used rather than static credentials. Ensure Workload Identities are first enabled on your GKE cluster: https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity"
 }
 
 variable "k8s_namespace" {

--- a/nomad-gcp/examples/basic/main.tf
+++ b/nomad-gcp/examples/basic/main.tf
@@ -29,7 +29,7 @@ variable "subnetwork" {
 
 variable "server_endpoint" {
   type    = string
-  default = "nomad.example.com.com:4647"
+  default = "example.com:4647"
 }
 
 

--- a/nomad-gcp/examples/docker_network/main.tf
+++ b/nomad-gcp/examples/docker_network/main.tf
@@ -64,7 +64,7 @@ variable "name" {
 variable "enable_workload_identity" {
   type        = bool
   default     = false
-  description = "If true, Workload Identity will be used rather than static credentials'"
+  description = "If true, Workload Identity will be used rather than static credentials. Ensure Workload Identities are first enabled on your GKE cluster: https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity"
 }
 
 variable "k8s_namespace" {

--- a/nomad-gcp/examples/docker_network/main.tf
+++ b/nomad-gcp/examples/docker_network/main.tf
@@ -33,7 +33,7 @@ variable "subnetwork" {
 
 variable "server_endpoint" {
   type    = string
-  default = "nomad.example.com:4647"
+  default = "example.com:4647"
 }
 
 

--- a/nomad-gcp/variables.tf
+++ b/nomad-gcp/variables.tf
@@ -152,7 +152,7 @@ variable "add_server_join" {
 variable "enable_workload_identity" {
   type        = bool
   default     = false
-  description = "If true, Workload Identity will be used rather than static credentials"
+  description = "If true, Workload Identity will be used rather than static credentials. Ensure Workload Identities are first enabled on your GKE cluster: https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity"
 }
 
 variable "k8s_namespace" {


### PR DESCRIPTION
:gear: **Issue**

<!-- What's wrong; why the change? A good place to reference the ticket if it exists. -->
our GCP docs do not:
- clarify that workload identities needs to be enabled on the GKE cluster to use the feature
- reference the single loadbalancer, instead it assumes there is a nomad subdomain

:white_check_mark: **Fix**

<!-- How did you fix the issue? -->
updated the docs

:question: **Tests**

<!-- Enumerate what you tested here. We 💖 screenshots and issue specific tests!-->

- [ ] Passed _reality check_
