### PR TITLE
Update default variable value for docker_network_cidr in GCP

### DIFF
--- a/nomad-gcp/variables.tf
+++ b/nomad-gcp/variables.tf
@@ -50,7 +50,7 @@ variable "docker_network_cidr" {
     This CIDR block should not be the same as your VPC CIDR block.
     i.e - "10.10.0.0/16" or "172.32.0.0/16" or "192.168.0.0/16"
     EOF
-  default     = "10.10.0.0/16"
+  default     = "192.168.0.0/16"
 }
 
 variable "min_replicas" {


### PR DESCRIPTION
:gear: **Issue**

[SERVER-1983](https://circleci.atlassian.net/browse/SERVER-1983)

:white_check_mark: **Fix**

Setting the default value to `192.168.0.0/16` for `variable "docker_network_cidr` for Nomads created in GCP.

:question: **Tests**

<!-- Enumerate what you tested here. We 💖 screenshots and issue specific tests!-->

- [ ] Passed _reality check_
