### PR TITLE
GCP Nomad Client - Additional Project Support and Key Output

### DIFF
--- a/nomad-gcp/nomad-autoscaler.tf
+++ b/nomad-gcp/nomad-autoscaler.tf
@@ -4,7 +4,7 @@ data "google_project" "project" {
 }
 
 locals {
-  project_id = var.project_id == "" ? data.google_project.project[0].project_id : var.project_id
+  project_id    = var.project_id == "" ? data.google_project.project[0].project_id : var.project_id
   output_sa_key = var.nomad_auto_scaler && !var.enable_workload_identity
 }
 

--- a/nomad-gcp/output.tf
+++ b/nomad-gcp/output.tf
@@ -27,7 +27,7 @@ output "managed_instance_group_zone" {
 }
 
 output "service_account_key" {
-  value       = base64decode(google_service_account_key.nomad-as-key[0].private_key)
+  value       = local.output_sa_key ? var.gcp_base64decode(google_service_account_key.nomad-as-key[0].private_key) : ""
   sensitive   = true
   description = "Base64 decoded service account key."
 }

--- a/nomad-gcp/output.tf
+++ b/nomad-gcp/output.tf
@@ -27,8 +27,8 @@ output "managed_instance_group_zone" {
 }
 
 output "service_account_key" {
-  value = base64decode(google_service_account_key.nomad-as-key[0].private_key)
-  sensitive = true
+  value       = base64decode(google_service_account_key.nomad-as-key[0].private_key)
+  sensitive   = true
   description = "Base64 decoded service account key."
 }
 

--- a/nomad-gcp/output.tf
+++ b/nomad-gcp/output.tf
@@ -26,6 +26,12 @@ output "managed_instance_group_zone" {
   value = google_compute_instance_group_manager.nomad.zone
 }
 
+output "service_account_key" {
+  value = base64decode(google_service_account_key.nomad-as-key[0].private_key)
+  sensitive = true
+  description = "Base64 decoded service account key."
+}
+
 output "service_account_key_location" {
   value = var.enable_workload_identity ? "" : "${path.cwd}/nomad-as-key.json"
 }

--- a/nomad-gcp/output.tf
+++ b/nomad-gcp/output.tf
@@ -27,7 +27,7 @@ output "managed_instance_group_zone" {
 }
 
 output "service_account_key" {
-  value       = local.output_sa_key ? var.gcp_base64decode(google_service_account_key.nomad-as-key[0].private_key) : ""
+  value       = local.output_sa_key ? base64decode(google_service_account_key.nomad-as-key[0].private_key) : ""
   sensitive   = true
   description = "Base64 decoded service account key."
 }

--- a/nomad-gcp/variables.tf
+++ b/nomad-gcp/variables.tf
@@ -1,7 +1,7 @@
 variable "project_id" {
   type        = string
   description = "GCP project ID to deploy resources into. By default uses the data sourced GCP project ID."
-  default = ""
+  default     = ""
 }
 
 variable "zone" {

--- a/nomad-gcp/variables.tf
+++ b/nomad-gcp/variables.tf
@@ -1,3 +1,9 @@
+variable "project_id" {
+  type        = string
+  description = "GCP project ID to deploy resources into. By default uses the data sourced GCP project ID."
+  default = ""
+}
+
 variable "zone" {
   type        = string
   description = "GCP compute zone to deploy nomad clients into (e.g us-east1-a)"


### PR DESCRIPTION
:gear: **Issue**
This change allows the upstream module to pass in a specific project_id to target. It also outputs the service account key as a sensitive output, in addition to writing it to the filesystem, so it can be more easily consumed by a parent module.

This re-merge reintroduces these changes, and fixes a bug that stops the module from trying to get the key as an output when the key does not exist.

:white_check_mark: **Fix**

:question: **Tests**

- [ ] Passed _reality check_
