### PR TITLE
Bump hashicorp/tls to work on m1 macs

### DIFF
--- a/shared/modules/tls/tls.tf
+++ b/shared/modules/tls/tls.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     tls = {
       source  = "hashicorp/tls"
-      version = "~> 2.2"
+      version = "~> 3.1"
     }
   }
 }


### PR DESCRIPTION
This was needed to run EKS `terraform init` on my new mac