### PR TITLE
chore: Remove KOTS, Nomad port, and update to 4.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,14 +16,14 @@ consume the AWS Nomad client module as follows:
 
 ```terraform
 module "my-aws-nomad-clients" {
-  # Pin release to 4.0.0 (for example) and use /nomad-aws subdirectory
-  source = "git::https://github.com/CircleCI-Public/server-terraform.git//nomad-aws?ref=4.0.0"
+  # Pin release to 4.1.0 (for example) and use /nomad-aws subdirectory
+  source = "git::https://github.com/CircleCI-Public/server-terraform.git//nomad-aws?ref=4.1.0"
 
   # Other variables here...
 }
 ```
 
-> Note the use of `ref=4.0.0` to select a specific git tag and
+> Note the use of `ref=4.1.0` to select a specific git tag and
 > `//nomad-aws` to select the `nomad-aws` module.
 
 [generic git repository]: https://www.terraform.io/docs/language/modules/sources.html#generic-git-repository
@@ -34,6 +34,7 @@ The modules in this repository are meant to be used with [terraform
 v0.15.4](https://releases.hashicorp.com/terraform/0.15.4/) and above.
 
 ### M1 Macbooks
+
 If using an M1 Macbook to run terraform init, plan, or apply commands, it's possible you may run into a versioning error with the hashicorp/tls provider. For this, we recommend the [m1-terraform-provider-helper](https://github.com/kreuzwerker/m1-terraform-provider-helper) CLI tool.
 
 First, navigate to the directory where you attempted the `terraform init/plan/apply` command and faced the error. Then run the following to install the provider compatible with the M1 Mac, double checking that the version matches that listed [here](shared/modules/tls/main.tf).

--- a/nomad-aws/README.md
+++ b/nomad-aws/README.md
@@ -33,7 +33,7 @@ module "nomad_clients" {
   subnet = "<< ID of subnet you want to run nomad clients in >>"
   vpc_id = "<< ID of VPC you want to run nomad client in >>"
 
-  server_endpoint = "<< hostname:port of nomad load balancer >>"
+  server_endpoint = "<< hostname of server installation >>"
 
   dns_server = "<< ip address of your VPC DNS server >>"
   blocked_cidrs = [
@@ -82,8 +82,7 @@ There are more examples in the [examples](./examples/) directory.
 | role_name | Name of the role to add to the instance profile | `string` | `null` | no |
 | volume\_type | The EBS volume type of the nomad nodes. If gp3 is not available in your desired region, switch to gp2 | `string` | `gp3` | no |
 | security\_group\_id | ID for the security group for Nomad clients.<br>See security documentation for recommendations. | `list(string)` | `[]` | no |
-| server\_endpoint | Domain of RPC service of Nomad control plane which is called "Nomad Load Balancer" in KOTs admin (e.g 127.0.0.1) | `string` | n/a | yes |
-| server\_port\_nomad | Port that the server endpoint listens on for nomad connections (defaults to 4647). | `number` |4647 | no |
+| server\_endpoint | Hostname of the server installation | `string` | n/a | yes |
 | ssh\_key | SSH Public key to access nomad nodes | `string` | `null` | no |
 | subnet | Subnet ID | `string` | `""` | yes* |
 | subnets | Subnet IDs | `list(string)` | `[""]` | yes* |

--- a/nomad-gcp/README.md
+++ b/nomad-gcp/README.md
@@ -21,7 +21,7 @@ module "nomad_clients" {
   zone            = "<< GCP compute zone to deploy nomad clients >>"
   region          = "<< GCP compute region to deploy nomad clients >>"
   network         = "default"
-  server_endpoint = "<< Hostname:port of nomad control plane >>"
+  server_endpoint = "<< Hostname of server installation >>"
   name            = "<< name prefix of nomad clients >>
 }
 
@@ -83,8 +83,7 @@ There are more examples in the [examples](./examples/) directory.
 | preemptible | Whether or not to use preemptible nodes | `bool` | `false` | no |
 | region | GCP region to deploy nomad clients into (e.g us-east1) | `string` | n/a | yes |
 | retry\_with\_ssh\_allowed\_cidr\_blocks | List of source IP CIDR blocks that can use the 'retry with SSH' feature of CircleCI jobs | `list(string)` | <pre>[<br>  "0.0.0.0/0"<br>]</pre> | no |
-| server\_endpoint | Domain of RPC service of Nomad control plane which is called "Nomad Load Balancer" in KOTs admin (e.g 127.0.0.1) | `string` | n/a | yes |
-| server\_port\_nomad | Port that the server endpoint listens on for nomad connections (defaults to 4647). | `number` |4647 | no |
+| server\_endpoint | Hostname of the server installation | `string` | n/a | yes |
 | target\_cpu\_utilization | Target CPU utilization to trigger autoscaling | `number` | `0.5` | no |
 | unsafe\_disable\_mtls | Disables mTLS between nomad client and servers. Compromises the authenticity and confidentiality of client-server communication. Should not be set to true in any production setting | `bool` | `false` | no |
 | zone | GCP compute zone to deploy nomad clients into (e.g us-east1-a) | `string` | n/a | yes |


### PR DESCRIPTION
:gear: **Issue**

SERVER-2358
We were still referencing KOTS and the Nomad port

:white_check_mark: **Fix**

Removed KOTS and Nomad port references
Updated 4.0.0 references to 4.1.0

:question: **Tests**

<!-- Enumerate what you tested here. We 💖 screenshots and issue specific tests!-->

- [ ] Passed _reality check_
