### PR TITLE
Add output descriptions for outputs used in Server 4.x Helm values

### DIFF
--- a/nomad-aws/README.md
+++ b/nomad-aws/README.md
@@ -95,10 +95,10 @@ There are more examples in the [examples](./examples/) directory.
 
 | Name | Description |
 |------|-------------|
-| mtls\_enabled | n/a |
+| mtls\_enabled | set this value for the `nomad.server.rpc.mTLS.enabled` key in the [CircleCI Server's Helm values.yaml](https://circleci.com/docs/server/installation/installation-reference/#all-values-yaml-options) |
 | nomad\_server\_cert | n/a |
 | nomad\_server\_key | n/a |
 | nomad\_tls\_ca | n/a |
-| nomad\_server\_cert\_base64 | n/a |
-| nomad\_server\_key\_base64 | n/a |
-| nomad\_tls\_ca\_base64 | n/a |
+| nomad\_server\_cert\_base64 | set this value for the `nomad.server.rpc.mTLS.certificate` key in the [CircleCI Server's Helm values.yaml](https://circleci.com/docs/server/installation/installation-reference/#all-values-yaml-options) |
+| nomad\_server\_key\_base64 | set this value for the `nomad.server.rpc.mTLS.privateKey` key in the [CircleCI Server's Helm values.yaml](https://circleci.com/docs/server/installation/installation-reference/#all-values-yaml-options) |
+| nomad\_tls\_ca\_base64 | set this value for the `nomad.server.rpc.mTLS.CACertificate` key in the [CircleCI Server's Helm values.yaml](https://circleci.com/docs/server/installation/installation-reference/#all-values-yaml-options) |

--- a/nomad-aws/output.tf
+++ b/nomad-aws/output.tf
@@ -1,5 +1,6 @@
 output "mtls_enabled" {
-  value = var.enable_mtls
+  description = "set this value for the `nomad.server.rpc.mTLS.enabled` key in the CircleCI Server's Helm values.yaml"
+  value       = var.enable_mtls
 }
 
 output "nomad_server_cert" {
@@ -15,15 +16,18 @@ output "nomad_tls_ca" {
 }
 
 output "nomad_server_cert_base64" {
-  value = var.enable_mtls ? base64encode(module.nomad_tls[0].nomad_server_cert) : ""
+  description = "set this value for the `nomad.server.rpc.mTLS.certificate` key in the CircleCI Server's Helm values.yaml"
+  value       = var.enable_mtls ? base64encode(module.nomad_tls[0].nomad_server_cert) : ""
 }
 
 output "nomad_server_key_base64" {
-  value = var.enable_mtls ? nonsensitive(base64encode(module.nomad_tls[0].nomad_server_key)) : ""
+  description = "set this value for the `nomad.server.rpc.mTLS.privateKey` key in the CircleCI Server's Helm values.yaml"
+  value       = var.enable_mtls ? nonsensitive(base64encode(module.nomad_tls[0].nomad_server_key)) : ""
 }
 
 output "nomad_tls_ca_base64" {
-  value = var.enable_mtls ? base64encode(module.nomad_tls[0].nomad_tls_ca) : ""
+  description = "set this value for the `nomad.server.rpc.mTLS.CACertificate` key in the CircleCI Server's Helm values.yaml"
+  value       = var.enable_mtls ? base64encode(module.nomad_tls[0].nomad_tls_ca) : ""
 }
 
 output "nomad_sg_id" {

--- a/nomad-gcp/README.md
+++ b/nomad-gcp/README.md
@@ -97,6 +97,6 @@ There are more examples in the [examples](./examples/) directory.
 | nomad\_server\_cert | n/a |
 | nomad\_server\_key | n/a |
 | nomad\_tls\_ca | n/a |
-| nomad\_server\_cert\_base64 | n/a |
-| nomad\_server\_key\_base64 | n/a |
-| nomad\_tls\_ca\_base64 | n/a |
+| nomad\_server\_cert\_base64 | set this value for the `nomad.server.rpc.mTLS.certificate` key in the [CircleCI Server's Helm values.yaml](https://circleci.com/docs/server/installation/installation-reference/#all-values-yaml-options) |
+| nomad\_server\_key\_base64 | set this value for the `nomad.server.rpc.mTLS.privateKey` key in the [CircleCI Server's Helm values.yaml](https://circleci.com/docs/server/installation/installation-reference/#all-values-yaml-options) |
+| nomad\_tls\_ca\_base64 | set this value for the `nomad.server.rpc.mTLS.CACertificate` key in the [CircleCI Server's Helm values.yaml](https://circleci.com/docs/server/installation/installation-reference/#all-values-yaml-options) |

--- a/nomad-gcp/output.tf
+++ b/nomad-gcp/output.tf
@@ -11,15 +11,18 @@ output "nomad_tls_ca" {
 }
 
 output "nomad_server_cert_base64" {
-  value = var.unsafe_disable_mtls ? "" : base64encode(module.tls[0].nomad_server_cert)
+  description = "set this value for the `nomad.server.rpc.mTLS.certificate` key in the CircleCI Server's Helm values.yaml"
+  value       = var.unsafe_disable_mtls ? "" : base64encode(module.tls[0].nomad_server_cert)
 }
 
 output "nomad_server_key_base64" {
-  value = var.unsafe_disable_mtls ? "" : nonsensitive(base64encode(module.tls[0].nomad_server_key))
+  description = "set this value for the `nomad.server.rpc.mTLS.privateKey` key in the CircleCI Server's Helm values.yaml"
+  value       = var.unsafe_disable_mtls ? "" : nonsensitive(base64encode(module.tls[0].nomad_server_key))
 }
 
 output "nomad_tls_ca_base64" {
-  value = var.unsafe_disable_mtls ? "" : base64encode(module.tls[0].nomad_tls_ca)
+  description = "set this value for the `nomad.server.rpc.mTLS.CACertificate` key in the CircleCI Server's Helm values.yaml"
+  value       = var.unsafe_disable_mtls ? "" : base64encode(module.tls[0].nomad_tls_ca)
 }
 
 output "managed_instance_group_name" {


### PR DESCRIPTION
:gear: **Issue**

Server customers may not recognize immediately where the generated base64 output from the Terraform stacks should be added w.r.t. the Helm values yaml: https://circleci.com/docs/server/installation/installation-reference/#all-values-yaml-options

<!-- What's wrong; why the change? A good place to reference the ticket if it exists. -->

:white_check_mark: **Fix**

A Server customer noted, ideally, it would be best if we (CircleCI) can help prepare a script to copy-paste these outputs to their Helm values.yaml .
This will avoid user errors from copy-pasting.

I think that may be something worth exploring.
However, in the meantime, we can definitely improve our documentation here, to let users know where these outputs are needed.

Hence, this PR adds the descriptions to the 3 required outputs from the TF stack.
We let users know where these outputs will be needed w.r.t to the Helm values.yaml file.

<!-- How did you fix the issue? -->

:question: **Tests**

<!-- Enumerate what you tested here. We 💖 screenshots and issue specific tests!-->

- [ ] Passed _reality check_
