### PR TITLE
Make EBS block size a variable in AWS nomad clients

### DIFF
--- a/nomad-aws/main.tf
+++ b/nomad-aws/main.tf
@@ -78,7 +78,7 @@ resource "aws_launch_template" "nomad_clients" {
 
     ebs {
       volume_type = var.volume_type
-      volume_size = 100
+      volume_size = var.ebs_volume_size_gb
     }
   }
 

--- a/nomad-aws/main.tf
+++ b/nomad-aws/main.tf
@@ -78,7 +78,7 @@ resource "aws_launch_template" "nomad_clients" {
 
     ebs {
       volume_type = var.volume_type
-      volume_size = var.ebs_volume_size_gb
+      volume_size = var.disk_size_gb
     }
   }
 

--- a/nomad-aws/variables.tf
+++ b/nomad-aws/variables.tf
@@ -141,6 +141,12 @@ variable "enable_irsa" {
   description = "If passed a valid OIDC MAP, terraform will create K8s Service Account Role to be used by nomad autoscaler."
 }
 
+variable "ebs_volume_size_gb" {
+  type = number
+  default = 100
+  description = "The volume size, in GB to each nomad client's /dev/sda1 disk."
+}
+
 
 locals {
   tags = merge({ "nomad-environment" = var.basename }, var.instance_tags)

--- a/nomad-aws/variables.tf
+++ b/nomad-aws/variables.tf
@@ -141,7 +141,7 @@ variable "enable_irsa" {
   description = "If passed a valid OIDC MAP, terraform will create K8s Service Account Role to be used by nomad autoscaler."
 }
 
-variable "ebs_volume_size_gb" {
+variable "disk_size_gb" {
   type = number
   default = 100
   description = "The volume size, in GB to each nomad client's /dev/sda1 disk."

--- a/nomad-gcp/variables.tf
+++ b/nomad-gcp/variables.tf
@@ -150,7 +150,7 @@ variable "disk_type" {
 variable "disk_size_gb" {
   type        = number
   default     = 300
-  description = "Root disk size in GB"
+  description = "Size of the root disk for nomad clients in GB."
 }
 
 variable "name" {


### PR DESCRIPTION
:gear: **Issue**
It was mentioned that the AWS EBS root disk size was hard-coded in AWS, but a variable in GCP.

:white_check_mark: **Fix**
This eliminates the 100gb hardcoding and adds a variable with a default of 100gb.

:question: **Tests**
- [] Passed _reality check_
