### PR TITLE
[SERVER-2496] Nomad machine images as variables

### DIFF
--- a/nomad-aws/README.md
+++ b/nomad-aws/README.md
@@ -88,6 +88,8 @@ There are more examples in the [examples](./examples/) directory.
 | subnets | Subnet IDs | `list(string)` | `[""]` | yes* |
 | vpc\_id | VPC ID of VPC used for Nomad resources | `string` | n/a | yes |
 | enable_irsa | Enable IAM Roles for K8s service account | `map` | `{}` | no |
+| machine_image_owners | List of AWS account IDs that own the images to be used for nomad virtual machines. | `list(string)` | `["099720109477", "513442679011"]` | no |
+| machine_image_names | Strings to filter image names for nomad virtual machine images. | `list(string)` | `["ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*"]` | no |
 
 * Note: `subnet` or `subnets` is required, but not both. The use of `subnet` will supersede `subnets`.
 

--- a/nomad-aws/examples/basic/main.tf
+++ b/nomad-aws/examples/basic/main.tf
@@ -15,8 +15,8 @@ provider "aws" {
 # An example VPC for demonstration. This might already exist if you deployed
 # server in a preexisting VPC and want your nomad clients to run there.
 module "vpc" {
-  source = "terraform-aws-modules/vpc/aws"
-  version = "4.0.2"
+  source               = "terraform-aws-modules/vpc/aws"
+  version              = "4.0.2"
   name                 = "nomad-vpc"
   cidr                 = "192.168.0.0/16"
   azs                  = ["us-east-1a"]

--- a/nomad-aws/examples/basic/main.tf
+++ b/nomad-aws/examples/basic/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~>4.66"
+      version = "~>4.35.0"
     }
   }
 }

--- a/nomad-aws/examples/basic/main.tf
+++ b/nomad-aws/examples/basic/main.tf
@@ -1,9 +1,9 @@
 terraform {
-  required_version = ">=1.4.6"
+  required_version = ">=1.1.9"
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~>4.35.0"
+      version = "~>4.66"
     }
   }
 }
@@ -16,7 +16,7 @@ provider "aws" {
 # server in a preexisting VPC and want your nomad clients to run there.
 module "vpc" {
   source = "terraform-aws-modules/vpc/aws"
-
+  version = "4.0.2"
   name                 = "nomad-vpc"
   cidr                 = "192.168.0.0/16"
   azs                  = ["us-east-1a"]

--- a/nomad-aws/main.tf
+++ b/nomad-aws/main.tf
@@ -18,10 +18,10 @@ data "aws_ami" "ubuntu_focal" {
 
   filter {
     name   = "name"
-    values = ["ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*"]
+    values = var.machine_image_names
   }
 
-  owners = ["099720109477", "513442679011"]
+  owners = var.machine_image_owners
 }
 
 module "nomad_tls" {

--- a/nomad-aws/variables.tf
+++ b/nomad-aws/variables.tf
@@ -151,3 +151,15 @@ locals {
   autoscaler_type = var.nomad_auto_scaler && length(var.enable_irsa) == 0 ? "user" : var.nomad_auto_scaler && length(var.enable_irsa) > 0 ? "role" : ""
 
 }
+
+variable "machine_image_owners" {
+  type = list(string)
+  description = "List of AWS accounts that own the images to be used for nomad virtual machines."
+  default = ["099720109477", "513442679011"]
+}
+
+variable "machine_image_names" {
+  type = list(string)
+  description = "Strings to filter image names for nomad virtual machine images."
+  default = ["ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*"]
+}

--- a/nomad-aws/variables.tf
+++ b/nomad-aws/variables.tf
@@ -153,13 +153,13 @@ locals {
 }
 
 variable "machine_image_owners" {
-  type = list(string)
+  type        = list(string)
   description = "List of AWS account IDs that own the images to be used for nomad virtual machines."
-  default = ["099720109477", "513442679011"]
+  default     = ["099720109477", "513442679011"]
 }
 
 variable "machine_image_names" {
-  type = list(string)
+  type        = list(string)
   description = "Strings to filter image names for nomad virtual machine images."
-  default = ["ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*"]
+  default     = ["ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*"]
 }

--- a/nomad-aws/variables.tf
+++ b/nomad-aws/variables.tf
@@ -154,7 +154,7 @@ locals {
 
 variable "machine_image_owners" {
   type = list(string)
-  description = "List of AWS accounts that own the images to be used for nomad virtual machines."
+  description = "List of AWS account IDs that own the images to be used for nomad virtual machines."
   default = ["099720109477", "513442679011"]
 }
 

--- a/nomad-gcp/README.md
+++ b/nomad-gcp/README.md
@@ -89,6 +89,8 @@ There are more examples in the [examples](./examples/) directory.
 | zone | GCP compute zone to deploy nomad clients into (e.g us-east1-a) | `string` | n/a | yes |
 | enable_workload_identity | Enable nomad service account as gcp workload identity. Ensure Workload Identities are first enabled on your GKE cluster: https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity | `bool` | `false` | no |
 | k8s_namespace | k8s namespace where application is installed | `string` | `circleci-server` | Yes, if enable_workload_identity is true |
+| machine_image_project | The project value used to retrieve the virtual machine image. | `string` | `ubuntu-os-cloud` | no |
+| machine_image_family | The family value used to retrieve the virtual machine image. | `string` | `ubuntu-2004-lts` | no |
 
 ## Outputs
 

--- a/nomad-gcp/main.tf
+++ b/nomad-gcp/main.tf
@@ -51,7 +51,7 @@ resource "google_compute_instance_template" "nomad" {
   tags = ["nomad", "circleci-server", "${var.name}-nomad-clients"]
 
   disk {
-    source_image = data.google_compute_image.ubuntu_2004.self_link
+    source_image = data.google_compute_image.machine_image.self_link
     disk_type    = var.disk_type
     disk_size_gb = var.disk_size_gb
     boot         = true
@@ -119,9 +119,9 @@ resource "google_compute_instance_group_manager" "nomad" {
   base_instance_name = "${var.name}-nomad"
 }
 
-data "google_compute_image" "ubuntu_2004" {
-  family  = "ubuntu-2004-lts"
-  project = "ubuntu-os-cloud"
+data "google_compute_image" "machine_image" {
+  family  = var.machine_image_family
+  project = var.machine_image_project
 }
 
 

--- a/nomad-gcp/variables.tf
+++ b/nomad-gcp/variables.tf
@@ -178,13 +178,13 @@ variable "k8s_namespace" {
 }
 
 variable "machine_image_project" {
-  type = string
+  type        = string
   description = "The project value used to retrieve the virtual machine image."
-  default = "ubuntu-os-cloud"
+  default     = "ubuntu-os-cloud"
 }
 
 variable "machine_image_family" {
-  type = string
+  type        = string
   description = "The family value used to retrieve the virtual machine image."
-  default = "ubuntu-2004-lts"
+  default     = "ubuntu-2004-lts"
 }

--- a/nomad-gcp/variables.tf
+++ b/nomad-gcp/variables.tf
@@ -176,3 +176,15 @@ variable "k8s_namespace" {
   default     = "circleci-server"
   description = "If enable_workload_identity is true, provide application k8s namespace"
 }
+
+variable "machine_image_project" {
+  type = string
+  description = "The project value used to retrieve the virtual machine image."
+  default = "ubuntu-os-cloud"
+}
+
+variable "machine_image_family" {
+  type = string
+  description = "The family value used to retrieve the virtual machine image."
+  default = "ubuntu-2004-lts"
+}


### PR DESCRIPTION
:gear: **Issue**
[SERVER-2496] - Currently nomad machine images are hardcoded and unable to be modified without forking.

:white_check_mark: **Fix**
This PR abstracts the hardcoded values to variables so they can be modified more easily. 

:question: **Tests**
- [ ] Passed _reality check_


[SERVER-2496]: https://circleci.atlassian.net/browse/SERVER-2496?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ