### PR TITLE
Fix #171 duplicate network setting causing docker-gc to fail on startup

### DIFF
--- a/nomad-aws/template/nomad-startup.sh.tpl
+++ b/nomad-aws/template/nomad-startup.sh.tpl
@@ -192,7 +192,6 @@ docker run \
   --interactive \
   --name "docker-gc" \
   --privileged \
-  --net=host \
   --userns=host \
   --volume /var/run/docker.sock:/var/run/docker.sock \
   --volume /var/lib/docker:/var/lib/docker:ro \

--- a/nomad-gcp/templates/nomad-startup.sh.tpl
+++ b/nomad-gcp/templates/nomad-startup.sh.tpl
@@ -192,7 +192,6 @@ setup_docker_gc() {
 	  --interactive \
 	  --name "docker-gc" \
 	  --privileged \
-	  --net=host \
 	  --userns=host \
 	  --volume /var/run/docker.sock:/var/run/docker.sock \
 	  --volume /var/lib/docker:/var/lib/docker:ro \


### PR DESCRIPTION
:gear: **Issue**

docker-gc is failing to start on nomad nodes and customer are seeing "error: no space left on device " on their jobs.
we notice the docker-gc container in the Nomad node are failing with the following error.

```
Jun 23 07:42:54 nomad-2vqh systemd[1]: Started Docker garbage collector.
Jun 23 07:42:56 nomad-2vqh docker-gc-start.rc[29688]: 2.0: Pulling from circleci/docker-gc
Jun 23 07:42:56 nomad-2vqh docker-gc-start.rc[29688]: Digest: sha256:439f9be316d6d07f7a7ac742f17adfe1a8386afeae01208542836ebc243f032c
Jun 23 07:42:56 nomad-2vqh docker-gc-start.rc[29688]: Status: Image is up to date for circleci/docker-gc:2.0
Jun 23 07:42:56 nomad-2vqh docker-gc-start.rc[29688]: docker.io/circleci/docker-gc:2.0
Jun 23 07:42:56 nomad-2vqh docker-gc-start.rc[29697]: Error response from daemon: No such container: docker-gc
Jun 23 07:42:56 nomad-2vqh docker-gc-start.rc[29705]: docker-gc
Jun 23 07:42:56 nomad-2vqh docker-gc-start.rc[29714]: docker: network-scoped aliases are only supported for user-defined networks.
Jun 23 07:42:56 nomad-2vqh docker-gc-start.rc[29714]: See 'docker run --help'.
Jun 23 07:42:56 nomad-2vqh systemd[1]: docker-gc.service: Main process exited, code=exited, status=125/n/a
Jun 23 07:42:56 nomad-2vqh systemd[1]: docker-gc.service: Failed with result 'exit-code'.
```

:white_check_mark: **Fix** #171 

It looks like having `--net=host` and `--network=ci-privileged`, `--network-alias=docker-gc.internal.circleci.com`  causes `docker: network-scoped aliases are only supported for user-defined networks.` resulting in docker-gc not starting.

To mitigate this @kelvintaywl had an idea to removed the duplicate network option `--net=host` and we saw the error message go away. Experimented on the following issue https://github.com/CircleCI-Public/server-terraform/issues/171#issuecomment-1602273906.

:question: **Tests**

We can confirm this by running `docker ps` and checking if docker-gc is running.

- [x] Check if docker-gc is running
- [x] Passed _reality check_ https://app.gke-circleci.nanophate.com/pipelines/github/nanophate-cci/realitycheck/2

Fixed Nomad Client output

<img width="1266" alt="Screenshot 2023-06-23 at 18 50 57" src="https://github.com/CircleCI-Public/server-terraform/assets/6015450/9a59fd02-92f6-4181-903a-6ed7b8997e06">

Broken Nomad Client output

<img width="1266" alt="Screenshot 2023-06-23 at 18 50 53" src="https://github.com/CircleCI-Public/server-terraform/assets/6015450/9f5a3373-e793-4534-9471-5d68d3285c34">

💯 Thanks

Thanks for @kelvintaywl to take a deeper look and helping me create this PR
