### PR TITLE
Use our latest patched version of nomad

### DIFF
--- a/nomad-aws/main.tf
+++ b/nomad-aws/main.tf
@@ -49,6 +49,7 @@ data "cloudinit_config" "nomad_user_data" {
     content = templatefile(
       "${path.module}/template/nomad-startup.sh.tpl",
       {
+        patched_nomad_version = var.patched_nomad_version
         nomad_server_endpoint = local.nomad_server_hostname_and_port
         client_tls_cert       = var.enable_mtls ? module.nomad_tls[0].nomad_client_cert : ""
         client_tls_key        = var.enable_mtls ? module.nomad_tls[0].nomad_client_key : ""

--- a/nomad-aws/template/nomad-startup.sh.tpl
+++ b/nomad-aws/template/nomad-startup.sh.tpl
@@ -82,8 +82,10 @@ echo "--------------------------------------"
 echo "         Installing nomad"
 echo "--------------------------------------"
 apt-get install -y zip
-curl -o nomad.zip https://releases.hashicorp.com/nomad/1.1.2/nomad_1.1.2_linux_amd64.zip
-unzip nomad.zip
+curl --retry 99 --retry-delay 1 --retry-connrefused -o linux_amd64.zip "https://circleci-binary-releases.s3.amazonaws.com/nomad/${patched_nomad_version}/linux_amd64.zip"
+curl --retry 99 --retry-delay 1 --retry-connrefused -o linux_amd64.zip.sha "https://circleci-binary-releases.s3.amazonaws.com/nomad/${patched_nomad_version}/linux_amd64.zip.sha"
+sha256sum -c linux_amd64.zip.sha || exit 1
+unzip linux_amd64.zip
 mv nomad /usr/bin
 
 echo "--------------------------------------"

--- a/nomad-aws/variables.tf
+++ b/nomad-aws/variables.tf
@@ -169,3 +169,9 @@ variable "machine_image_names" {
   description = "Strings to filter image names for nomad virtual machine images."
   default     = ["ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*"]
 }
+
+variable "patched_nomad_version" {
+  type        = string
+  description = "The version of CircleCI's fork Nomad to install"
+  default     = "1.4.568-bfc9a6ec4"
+}

--- a/nomad-gcp/main.tf
+++ b/nomad-gcp/main.tf
@@ -61,6 +61,7 @@ resource "google_compute_instance_template" "nomad" {
   metadata_startup_script = templatefile(
     "${path.module}/templates/nomad-startup.sh.tpl",
     {
+      patched_nomad_version = var.patched_nomad_version
       add_server_join       = var.add_server_join ? var.add_server_join : ""
       nomad_server_endpoint = local.nomad_server_hostname_and_port
       blocked_cidrs         = var.blocked_cidrs

--- a/nomad-gcp/templates/nomad-startup.sh.tpl
+++ b/nomad-gcp/templates/nomad-startup.sh.tpl
@@ -79,8 +79,10 @@ configure_circleci() {
 install_nomad() {
 	log "Installing Nomad"
 	install zip
-	curl -o nomad.zip https://releases.hashicorp.com/nomad/1.1.2/nomad_1.1.2_linux_amd64.zip
-	unzip nomad.zip
+	curl --retry 99 --retry-delay 1 --retry-connrefused -o linux_amd64.zip "https://circleci-binary-releases.s3.amazonaws.com/nomad/${patched_nomad_version}/linux_amd64.zip"
+	curl --retry 99 --retry-delay 1 --retry-connrefused -o linux_amd64.zip.sha "https://circleci-binary-releases.s3.amazonaws.com/nomad/${patched_nomad_version}/linux_amd64.zip.sha"
+	sha256sum -c linux_amd64.zip.sha || exit 1
+	unzip linux_amd64.zip
 	mv nomad /usr/bin
 }
 

--- a/nomad-gcp/variables.tf
+++ b/nomad-gcp/variables.tf
@@ -188,3 +188,9 @@ variable "machine_image_family" {
   description = "The family value used to retrieve the virtual machine image."
   default     = "ubuntu-2004-lts"
 }
+
+variable "patched_nomad_version" {
+  type        = string
+  description = "The version of CircleCI's fork Nomad to install"
+  default     = "1.4.568-bfc9a6ec4"
+}


### PR DESCRIPTION
:gear: EXEC-3305

<!-- What's wrong; why the change? A good place to reference the ticket if it exists. -->

:white_check_mark: Updates Nomad to our latest forked version ahead of the next release

<!-- How did you fix the issue? -->

:question: Tested in EXECs AWS cluster

<!-- Enumerate what you tested here. We 💖 screenshots and issue specific tests!-->

- [ ] Passed _reality check_ - We are still working on reality check for the new services
