### PR TITLE
Add support for IMDSv2 configured via variable

### DIFF
--- a/nomad-aws/README.md
+++ b/nomad-aws/README.md
@@ -52,6 +52,8 @@ module "nomad_clients" {
 
   ssh_key = "<< public key to be placed on each nomad client >>"
   basename = "<< name prefix for nomad clients >>"
+
+  enable_imdsv2 = "<< optional/required >>"
 }
 
 output "nomad" {
@@ -117,6 +119,7 @@ There are more examples in the [examples](./examples/) directory.
 | <a name="input_disk_size_gb"></a> [disk\_size\_gb](#input\_disk\_size\_gb) | The volume size, in GB to each nomad client's /dev/sda1 disk. | `number` | `100` | no |
 | <a name="input_dns_server"></a> [dns\_server](#input\_dns\_server) | If the IP address of your VPC DNS server is within one of the blocked CIDR blocks you can create an exemption by entering the IP address for it here | `string` | n/a | yes |
 | <a name="input_docker_network_cidr"></a> [docker\_network\_cidr](#input\_docker\_network\_cidr) | IP CIDR to be used in docker networks when running job on nomad client.<br>This CIDR block should not be the same as your VPC CIDR block.<br>i.e - "10.10.0.0/16" or "172.32.0.0/16" or "192.168.0.0/16" | `string` | `"10.10.0.0/16"` | no |
+| <a name="input_enable_imdsv2"></a> [enable\_imdsv2](#input\_enable\_imdsv2) | Enabling or Disabling IMDSv2 on the Nomad clients. IMDSv2 is only supported on CircleCI Server 4.6.0 or greater. | `string` | `optional` | no |
 | <a name="input_enable_irsa"></a> [enable\_irsa](#input\_enable\_irsa) | If passed a valid OIDC MAP, terraform will create K8s Service Account Role to be used by nomad autoscaler. | `map(any)` | `{}` | no |
 | <a name="input_enable_mtls"></a> [enable\_mtls](#input\_enable\_mtls) | MTLS support for Nomad traffic. Modifying this can be dangerous and is not recommended. | `bool` | `true` | no |
 | <a name="input_instance_tags"></a> [instance\_tags](#input\_instance\_tags) | n/a | `map(string)` | <pre>{<br>  "vendor": "circleci"<br>}</pre> | no |

--- a/nomad-aws/main.tf
+++ b/nomad-aws/main.tf
@@ -76,7 +76,7 @@ resource "aws_launch_template" "nomad_clients" {
   key_name      = var.ssh_key != null ? aws_key_pair.ssh_key[0].id : null
 
   metadata_options {
-    http_tokens = "required"
+    http_tokens = var.enable_imdsv2
   }
 
   block_device_mappings {

--- a/nomad-aws/variables.tf
+++ b/nomad-aws/variables.tf
@@ -187,3 +187,9 @@ variable "allowed_ips_circleci_server_nomad_access" {
   description = "List of IPv4 ranges that are permitted to access nomad nodes; used for circleci-server-to-nomad communication"
   default     = ["0.0.0.0/0"]
 }
+
+variable "enable_imdsv2" {
+  type        = string
+  description = "Enable or Disable IMDSv2 on Nomad clients. Optional or Required. This is only supported on, or after, CircleCI Server 4.6.0" 
+  default     = "optional"
+}


### PR DESCRIPTION
:gear: **Issue**
Rerun with SSH on Docker is currently broken on CircleCI Server >4.6.0.

<!-- What's wrong; why the change? A good place to reference the ticket if it exists. -->

:white_check_mark: **Fix**
Make IMDSv2 configurable with a default of `optional`.

<!-- How did you fix the issue? -->

:question: **Tests**
Tested this works via a variable on a personal repository.

<!-- Enumerate what you tested here. We 💖 screenshots and issue specific tests!-->

- [ ] Passed _reality check_
