### PR TITLE
using nomad from hashi

### DIFF
--- a/nomad-aws/README.md
+++ b/nomad-aws/README.md
@@ -132,7 +132,7 @@ There are more examples in the [examples](./examples/) directory.
 | <a name="input_nomad_auto_scaler"></a> [nomad\_auto\_scaler](#input\_nomad\_auto\_scaler) | If set to true, A Nomad User or A Role will be created based on enable\_irsa variable values | `bool` | `false` | no |
 | <a name="input_nomad_server_hostname"></a> [nomad\_server\_hostname](#input\_nomad\_server\_hostname) | Hostname of RPC service of Nomad control plane (e.g circleci.example.com) | `string` | n/a | yes |
 | <a name="input_nomad_server_port"></a> [nomad\_server\_port](#input\_nomad\_server\_port) | Port that the server endpoint listens on for nomad connections. | `number` | `4647` | no |
-| <a name="input_patched_nomad_version"></a> [patched\_nomad\_version](#input\_patched\_nomad\_version) | The version of CircleCI's fork Nomad to install | `string` | `"1.4.568-bfc9a6ec4"` | no |
+| <a name="input_nomad_version"></a> [nomad\_version](#input\_nomad\_version) | The version of Nomad to install | `string` | `"1.9.7-1"` | no |
 | <a name="input_role_name"></a> [role\_name](#input\_role\_name) | Name of the role to add to the instance profile | `string` | `null` | no |
 | <a name="input_security_group_id"></a> [security\_group\_id](#input\_security\_group\_id) | ID for the security group for Nomad clients.<br/>See security documentation for recommendations. | `list(string)` | `[]` | no |
 | <a name="input_ssh_key"></a> [ssh\_key](#input\_ssh\_key) | SSH Public key to access nomad nodes | `string` | `null` | no |

--- a/nomad-aws/main.tf
+++ b/nomad-aws/main.tf
@@ -49,7 +49,7 @@ data "cloudinit_config" "nomad_user_data" {
     content = templatefile(
       "${path.module}/template/nomad-startup.sh.tpl",
       {
-        nomad_version = var.nomad_version
+        nomad_version         = var.nomad_version
         nomad_server_endpoint = local.nomad_server_hostname_and_port
         client_tls_cert       = var.enable_mtls ? module.nomad_tls[0].nomad_client_cert : ""
         client_tls_key        = var.enable_mtls ? module.nomad_tls[0].nomad_client_key : ""

--- a/nomad-aws/main.tf
+++ b/nomad-aws/main.tf
@@ -49,7 +49,7 @@ data "cloudinit_config" "nomad_user_data" {
     content = templatefile(
       "${path.module}/template/nomad-startup.sh.tpl",
       {
-        patched_nomad_version = var.patched_nomad_version
+        nomad_version = var.nomad_version
         nomad_server_endpoint = local.nomad_server_hostname_and_port
         client_tls_cert       = var.enable_mtls ? module.nomad_tls[0].nomad_client_cert : ""
         client_tls_key        = var.enable_mtls ? module.nomad_tls[0].nomad_client_key : ""

--- a/nomad-aws/template/nomad-startup.sh.tpl
+++ b/nomad-aws/template/nomad-startup.sh.tpl
@@ -81,12 +81,12 @@ fi
 echo "--------------------------------------"
 echo "         Installing nomad"
 echo "--------------------------------------"
-apt-get install -y zip
-curl --retry 99 --retry-delay 1 --retry-connrefused -o linux_amd64.zip "https://circleci-binary-releases.s3.amazonaws.com/nomad/${patched_nomad_version}/linux_amd64.zip"
-curl --retry 99 --retry-delay 1 --retry-connrefused -o linux_amd64.zip.sha "https://circleci-binary-releases.s3.amazonaws.com/nomad/${patched_nomad_version}/linux_amd64.zip.sha"
-sha256sum -c linux_amd64.zip.sha || exit 1
-unzip linux_amd64.zip
-mv nomad /usr/bin
+sudo apt-get update && \
+sudo apt-get install wget gpg coreutils
+wget -O- https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
+echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
+sudo apt-get update && sudo apt-get install nomad=${nomad_version}
+
 
 echo "--------------------------------------"
 echo "       Installling TLS certs"

--- a/nomad-aws/variables.tf
+++ b/nomad-aws/variables.tf
@@ -170,10 +170,10 @@ variable "machine_image_names" {
   default     = ["ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*"]
 }
 
-variable "patched_nomad_version" {
+variable "nomad_version" {
   type        = string
-  description = "The version of CircleCI's fork Nomad to install"
-  default     = "1.4.568-bfc9a6ec4"
+  description = "The version of Nomad to install"
+  default     = "1.9.7-1"
 }
 
 variable "allowed_ips_retry_ssh" {

--- a/nomad-gcp/README.md
+++ b/nomad-gcp/README.md
@@ -96,7 +96,7 @@ There are more examples in the [examples](./examples/) directory.
 | <a name="input_nomad_auto_scaler"></a> [nomad\_auto\_scaler](#input\_nomad\_auto\_scaler) | If true, terraform will create a service account to be used by nomad autoscaler. | `bool` | `false` | no |
 | <a name="input_nomad_server_hostname"></a> [nomad\_server\_hostname](#input\_nomad\_server\_hostname) | Hostname of RPC service of Nomad control plane (e.g circleci.example.com) | `string` | n/a | yes |
 | <a name="input_nomad_server_port"></a> [nomad\_server\_port](#input\_nomad\_server\_port) | Port that the server endpoint listens on for nomad connections. | `number` | `4647` | no |
-| <a name="input_patched_nomad_version"></a> [patched\_nomad\_version](#input\_patched\_nomad\_version) | The version of CircleCI's fork Nomad to install | `string` | `"1.4.568-bfc9a6ec4"` | no |
+| <a name="input_nomad_version"></a> [nomad\_version](#input\_nomad\_version) | The version of Nomad to install | `string` | `"1.9.7-1"` | no |
 | <a name="input_preemptible"></a> [preemptible](#input\_preemptible) | Whether or not to use preemptible nodes | `bool` | `false` | no |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | GCP project ID to deploy resources into. By default uses the data sourced GCP project ID. | `string` | `""` | no |
 | <a name="input_region"></a> [region](#input\_region) | GCP region to deploy nomad clients into (e.g us-east1) | `string` | n/a | yes |

--- a/nomad-gcp/main.tf
+++ b/nomad-gcp/main.tf
@@ -61,7 +61,7 @@ resource "google_compute_instance_template" "nomad" {
   metadata_startup_script = templatefile(
     "${path.module}/templates/nomad-startup.sh.tpl",
     {
-      patched_nomad_version = var.patched_nomad_version
+      nomad_version         = var.nomad_version
       add_server_join       = var.add_server_join ? var.add_server_join : ""
       nomad_server_endpoint = local.nomad_server_hostname_and_port
       blocked_cidrs         = var.blocked_cidrs

--- a/nomad-gcp/templates/nomad-startup.sh.tpl
+++ b/nomad-gcp/templates/nomad-startup.sh.tpl
@@ -78,12 +78,11 @@ configure_circleci() {
 
 install_nomad() {
 	log "Installing Nomad"
-	install zip
-	curl --retry 99 --retry-delay 1 --retry-connrefused -o linux_amd64.zip "https://circleci-binary-releases.s3.amazonaws.com/nomad/${patched_nomad_version}/linux_amd64.zip"
-	curl --retry 99 --retry-delay 1 --retry-connrefused -o linux_amd64.zip.sha "https://circleci-binary-releases.s3.amazonaws.com/nomad/${patched_nomad_version}/linux_amd64.zip.sha"
-	sha256sum -c linux_amd64.zip.sha || exit 1
-	unzip linux_amd64.zip
-	mv nomad /usr/bin
+	sudo apt-get update && \
+	sudo apt-get install wget gpg coreutils
+	wget -O- https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
+	echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
+	sudo apt-get update && sudo apt-get install nomad=${nomad_version}
 }
 
 configure_nomad() {

--- a/nomad-gcp/variables.tf
+++ b/nomad-gcp/variables.tf
@@ -189,8 +189,8 @@ variable "machine_image_family" {
   default     = "ubuntu-2004-lts"
 }
 
-variable "patched_nomad_version" {
+variable "nomad_version" {
   type        = string
-  description = "The version of CircleCI's fork Nomad to install"
-  default     = "1.4.568-bfc9a6ec4"
+  description = "The version of Nomad to install"
+  default     = "1.9.7-1"
 }


### PR DESCRIPTION
up till now we've used the circleci nomad image which we would like to move away from maintaining to lower our internal burden. this PR replaces the circleci image with nomad directly from hashicorp.