### PR TITLE
ONPREM-2030 | updated server_retry_join value for aws nomad client

### DIFF
--- a/nomad-aws/main.tf
+++ b/nomad-aws/main.tf
@@ -1,5 +1,6 @@
 locals {
   nomad_server_hostname_and_port = "${var.nomad_server_hostname}:${var.nomad_server_port}"
+  server_retry_join              = "provider=aws tag_key=${var.tag_key_for_discover} tag_value=${var.tag_value_for_discover} addr_type=${var.addr_type} region=${var.aws_region}"
 }
 
 resource "random_string" "key_suffix" {
@@ -57,10 +58,7 @@ data "cloudinit_config" "nomad_user_data" {
         blocked_cidrs         = var.blocked_cidrs
         docker_network_cidr   = var.docker_network_cidr
         dns_server            = var.dns_server
-        tag_key               = var.tag_key_for_discover
-        tag_value             = var.tag_value_for_discover
-        addr_type             = var.addr_type
-        region                = var.aws_region
+        server_retry_join     = var.nomad_server_enabled ? local.server_retry_join : local.nomad_server_hostname_and_port
       }
     )
   }

--- a/nomad-aws/template/nomad-startup.sh.tpl
+++ b/nomad-aws/template/nomad-startup.sh.tpl
@@ -121,7 +121,7 @@ client {
     enabled = true
     # Expecting to have DNS record for nomad server(s)
     server_join {
-        retry_join = ["provider="aws" tag_key="${tag_key}" tag_value=${tag_value} addr_type=${addr_type} region=${region}"]
+        retry_join = ["${server_retry_join}"]
         retry_max  = 30
         retry_interval = "30s"
     }


### PR DESCRIPTION
:gear: **Issue**
- `server_retry_join` value is not switching based on `nomad_server_enabled`

:white_check_mark: **Fix**
- Updated the derived value for `server_retry_join` based on whether nomad-server is enabled or not

