### PR TITLE
ONPREM-2030 | update nomad autoscaler aws policy

### DIFF
--- a/nomad-aws/template/nomad_asg_policy.tpl
+++ b/nomad-aws/template/nomad_asg_policy.tpl
@@ -16,7 +16,8 @@
             "Effect": "Allow",
             "Action": [
                 "autoscaling:DescribeScalingActivities",
-                "autoscaling:DescribeAutoScalingGroups"
+                "autoscaling:DescribeAutoScalingGroups",
+                "autoscaling:DescribeInstanceRefreshes"
             ],
             "Resource": "*"
         }


### PR DESCRIPTION
:gear: **Issue**
- Nomad AWS Autoscaling is not working due 403 error when evaluating the policy. 

:white_check_mark: **Fix**
- Added `autoscaling:DescribeInstanceRefreshes` in nomad IAM policy
