### PR TITLE
ONPREM | nomad role condition update

### DIFF
--- a/nomad-aws/main.tf
+++ b/nomad-aws/main.tf
@@ -3,7 +3,7 @@ locals {
   nomad_host_name_if_server      = var.nomad_server_enabled && var.nomad_server_hostname == "" ? "${var.basename}-circleci-nomad-server-nlb-*.elb.${var.aws_region}.amazonaws.com" : var.nomad_server_hostname
   nomad_server_hostname_and_port = "${local.nomad_host_name_if_server}:${var.nomad_server_port}"
   server_retry_join              = "provider=aws tag_key=${var.tag_key_for_discover} tag_value=${var.tag_value_for_discover} addr_type=${var.addr_type} region=${var.aws_region}"
-  nomad_client_instance_role     = var.role_name != null ? var.role_name : aws_iam_role.nomad_instance_role[0].name
+  nomad_client_instance_role     = var.role_name != null ? var.role_name : (var.nomad_server_enabled ? aws_iam_role.nomad_instance_role[0].name : null)
 
   instance_tags = merge(var.instance_tags, { "type" = "nomad-client" })
 }

--- a/nomad-aws/role.tf
+++ b/nomad-aws/role.tf
@@ -26,9 +26,9 @@ data "aws_iam_policy_document" "assume_ec2_policy" {
   }
 }
 
-// Create the role if var.role_name is null and nomad server is enabled 
+// Create the role only if nomad server is enabled  and var.role_name is null
 resource "aws_iam_role" "nomad_instance_role" {
-  count = var.nomad_server_enabled && var.role_name != null ? 0 : 1
+  count = var.nomad_server_enabled && var.role_name == null ? 1 : 0
 
   name               = "${var.basename}-circleci-nomad-clients-instance-role"
   assume_role_policy = data.aws_iam_policy_document.assume_ec2_policy.json
@@ -36,7 +36,7 @@ resource "aws_iam_role" "nomad_instance_role" {
 }
 
 resource "aws_iam_role_policy_attachment" "attach_policy_to_role" {
-  count = var.nomad_server_enabled && var.role_name != null ? 0 : 1
+  count = var.nomad_server_enabled && var.role_name == null ? 1 : 0
 
   role       = aws_iam_role.nomad_instance_role[0].name
   policy_arn = aws_iam_policy.describe_ec2_policy[0].arn


### PR DESCRIPTION
**Role creation condition update for Nomad AWS**

- `"${var.basename}-circleci-nomad-clients-instance-role"` will be created only if nomad server is enabled and role is null
- Fixed the derivation for `nomad_client_instance_role` for the same above case