### PR TITLE
ONPREM-1744 | update gcp provider version

### DIFF
--- a/nomad-gcp/README.md
+++ b/nomad-gcp/README.md
@@ -39,13 +39,13 @@ There are more examples in the [examples](./examples/) directory.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_google"></a> [google](#requirement\_google) | ~> 3.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | ~> 5.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | ~> 3.0 |
+| <a name="provider_google"></a> [google](#provider\_google) | ~> 5.0 |
 | <a name="provider_local"></a> [local](#provider\_local) | n/a |
 
 ## Modules

--- a/nomad-gcp/nomad-autoscaler.tf
+++ b/nomad-gcp/nomad-autoscaler.tf
@@ -18,15 +18,17 @@ resource "google_service_account" "nomad_as_service_account" {
 }
 
 resource "google_project_iam_member" "nomad_as_compute_autoscalers_get" {
-  count  = var.nomad_auto_scaler ? 1 : 0
-  role   = "roles/compute.admin"
-  member = "serviceAccount:${google_service_account.nomad_as_service_account[0].email}"
+  count   = var.nomad_auto_scaler ? 1 : 0
+  project = local.project_id
+  role    = "roles/compute.admin"
+  member  = "serviceAccount:${google_service_account.nomad_as_service_account[0].email}"
 }
 
 resource "google_project_iam_member" "nomad_as_work_identity" {
-  count  = var.nomad_auto_scaler && var.enable_workload_identity ? 1 : 0
-  role   = "roles/iam.workloadIdentityUser"
-  member = "serviceAccount:${google_service_account.nomad_as_service_account[0].email}"
+  count   = var.nomad_auto_scaler && var.enable_workload_identity ? 1 : 0
+  project = local.project_id
+  role    = "roles/iam.workloadIdentityUser"
+  member  = "serviceAccount:${google_service_account.nomad_as_service_account[0].email}"
 }
 
 resource "google_service_account_iam_binding" "nomad_as_work_identity_k8s" {

--- a/nomad-gcp/versions.tf
+++ b/nomad-gcp/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     google = {
-      version = "~> 3.0"
+      version = "~> 5.0"
       // NOTE: This can be set to hashicorp/google once scaling_schedules are
       // out of beta on google_compute_autoscaler resources
       source = "hashicorp/google-beta"


### PR DESCRIPTION
:gear: **Issue**
- GCP provider version update to allow tags/labels  as default

