### PR TITLE
Downgrading Nomad Version for GCP and AWS both

### DIFF
--- a/nomad-aws/README.md
+++ b/nomad-aws/README.md
@@ -147,7 +147,7 @@ There are more examples in the [examples](./examples/) directory.
 | <a name="input_nomad_server_enabled"></a> [nomad\_server\_enabled](#input\_nomad\_server\_enabled) | Set to true to enable nomad server | `bool` | `false` | no |
 | <a name="input_nomad_server_hostname"></a> [nomad\_server\_hostname](#input\_nomad\_server\_hostname) | Hostname of RPC service of Nomad control plane (e.g circleci.example.com) | `string` | n/a | yes |
 | <a name="input_nomad_server_port"></a> [nomad\_server\_port](#input\_nomad\_server\_port) | Port that the server endpoint listens on for nomad connections. | `number` | `4647` | no |
-| <a name="input_nomad_version"></a> [nomad\_version](#input\_nomad\_version) | The version of Nomad to install | `string` | `"1.9.7-1"` | no |
+| <a name="input_nomad_version"></a> [nomad\_version](#input\_nomad\_version) | The version of Nomad to install | `string` | `"1.6.1-1"` | no |
 | <a name="input_role_name"></a> [role\_name](#input\_role\_name) | Name of the role to add to the instance profile | `string` | `null` | no |
 | <a name="input_security_group_id"></a> [security\_group\_id](#input\_security\_group\_id) | ID for the security group for Nomad clients.<br/>See security documentation for recommendations. | `list(string)` | `[]` | no |
 | <a name="input_server_disk_size_gb"></a> [server\_disk\_size\_gb](#input\_server\_disk\_size\_gb) | Disk size for nomad server instances | `number` | `20` | no |

--- a/nomad-aws/variables.tf
+++ b/nomad-aws/variables.tf
@@ -188,7 +188,7 @@ variable "machine_image_names" {
 variable "nomad_version" {
   type        = string
   description = "The version of Nomad to install"
-  default     = "1.9.7-1"
+  default     = "1.6.1-1"
 }
 
 variable "allowed_ips_retry_ssh" {

--- a/nomad-gcp/README.md
+++ b/nomad-gcp/README.md
@@ -103,7 +103,7 @@ There are more examples in the [examples](./examples/) directory.
 | <a name="input_nomad_server_enabled"></a> [nomad\_server\_enabled](#input\_nomad\_server\_enabled) | Set to true to enable nomad server | `bool` | `false` | no |
 | <a name="input_nomad_server_hostname"></a> [nomad\_server\_hostname](#input\_nomad\_server\_hostname) | Hostname of RPC service of Nomad control plane (e.g circleci.example.com) | `string` | n/a | yes |
 | <a name="input_nomad_server_port"></a> [nomad\_server\_port](#input\_nomad\_server\_port) | Port that the server endpoint listens on for nomad connections. | `number` | `4647` | no |
-| <a name="input_nomad_version"></a> [nomad\_version](#input\_nomad\_version) | The version of Nomad to install | `string` | `"1.9.7-1"` | no |
+| <a name="input_nomad_version"></a> [nomad\_version](#input\_nomad\_version) | The version of Nomad to install | `string` | `"1.6.1-1"` | no |
 | <a name="input_preemptible"></a> [preemptible](#input\_preemptible) | Whether or not to use preemptible nodes | `bool` | `false` | no |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | GCP project ID to deploy resources into. By default uses the data sourced GCP project ID. | `string` | `""` | no |
 | <a name="input_region"></a> [region](#input\_region) | GCP region to deploy nomad clients into (e.g us-east1) | `string` | n/a | yes |

--- a/nomad-gcp/variables.tf
+++ b/nomad-gcp/variables.tf
@@ -192,7 +192,7 @@ variable "machine_image_family" {
 variable "nomad_version" {
   type        = string
   description = "The version of Nomad to install"
-  default     = "1.9.7-1"
+  default     = "1.6.1-1"
 }
 
 


### PR DESCRIPTION
:gear: **Issue**
- Job is getting "queued" and correct status is not being reported 

:white_check_mark: **Fix**
- Downgraded the version to working one `1.6.1-1`

