### PR TITLE
ONPREM-2220 | fix gcp install script

### DIFF
--- a/nomad-gcp/modules/nomad-server-gcp/templates/nomad-server-startup.sh.tpl
+++ b/nomad-gcp/modules/nomad-server-gcp/templates/nomad-server-startup.sh.tpl
@@ -6,7 +6,8 @@ log() {
 	msg=$1
 	color="\e[1;36m" # Bold, Cyan
 	reset="\e[0m"
-	echo -e "$${color}$${msg}$${reset}"
+	# echo -e "$${color}$${msg}$${reset}"
+	echo -e "$${msg}"
 }
 
 tune_io_scheduler() {
@@ -53,6 +54,8 @@ install_nomad() {
 	else
 		install nomad=${nomad_version}
 	fi
+
+	nomad --version || ( echo "Nomad failed to install" && exit 1 )
 }
 
 configure_nomad() {
@@ -164,5 +167,5 @@ system_update
 install ntp
 install jq
 
-install_nomad
+install_nomad || exit 1
 configure_nomad

--- a/nomad-gcp/templates/nomad-startup.sh.tpl
+++ b/nomad-gcp/templates/nomad-startup.sh.tpl
@@ -6,7 +6,8 @@ log() {
 	msg=$1
 	color="\e[1;36m" # Bold, Cyan
 	reset="\e[0m"
-	echo -e "$${color}$${msg}$${reset}"
+	#echo -e "$${color}$${msg}$${reset}"
+	echo -e "$${msg}"
 }
 
 tune_io_scheduler() {
@@ -81,9 +82,6 @@ configure_circleci() {
 		mkdir -p /etc/circleci
 		echo $private_ip | tee /etc/circleci/public-ipv4
 	fi
-
-	circleci version || ( echo "CircleCI CLI failed to install" && exit 1 )
-
 }
 
 install_nomad() {
@@ -250,7 +248,7 @@ install jq
 
 enabled_docker_userns
 configure_circleci
-install_nomad
+install_nomad || exit 1
 configure_nomad
 
 create_ci_network


### PR DESCRIPTION
- There is no circleci install, hence removed the circleci check
- Logs are not printing in color, hence removed log logic
- Now script will exist if Nomad Install is not successful