### PR TITLE
Creating Nomad SSL Directory in nomad-gcp

### DIFF
--- a/nomad-gcp/modules/nomad-server-gcp/templates/nomad-server-startup.sh.tpl
+++ b/nomad-gcp/modules/nomad-server-gcp/templates/nomad-server-startup.sh.tpl
@@ -64,7 +64,8 @@ configure_nomad() {
 	log "-----------------------------------------"
 	log "Installing TLS Certificates"
 	log "-----------------------------------------"
-	
+
+	mkdir -p /etc/nomad/ssl
 	chmod 0700 /etc/nomad/ssl
 	
 	cat <<-EOT > /etc/nomad/ssl/cert.pem


### PR DESCRIPTION
:gear: **Issue**
- `/etc/nomad/ssl` directory does not exists in `nomad-gcp`

:white_check_mark: **Fix**
- Added a `mkdir` command to create the dir

