### PR TITLE
ONPREM-2249 | Restrict nomad traffic within vpc for AWS Nomad

### DIFF
--- a/nomad-aws/README.md
+++ b/nomad-aws/README.md
@@ -80,9 +80,9 @@ There are more examples in the [examples](./examples/) directory.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5 |
-| <a name="provider_cloudinit"></a> [cloudinit](#provider\_cloudinit) | >=2.3 |
-| <a name="provider_random"></a> [random](#provider\_random) | n/a |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.98.0 |
+| <a name="provider_cloudinit"></a> [cloudinit](#provider\_cloudinit) | 2.3.7 |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.7.2 |
 
 ## Modules
 
@@ -108,12 +108,14 @@ There are more examples in the [examples](./examples/) directory.
 | [aws_key_pair.ssh_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/key_pair) | resource |
 | [aws_launch_template.nomad_clients](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/launch_template) | resource |
 | [aws_security_group.nomad_sg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
+| [aws_security_group.nomad_traffic_sg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_security_group.ssh_sg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [random_string.key_suffix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
 | [aws_ami.ubuntu_focal](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
 | [aws_iam_policy_document.assume_ec2_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.ec2_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_role.existing_nomad_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_role) | data source |
+| [aws_vpc.nomad](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc) | data source |
 | [cloudinit_config.nomad_user_data](https://registry.terraform.io/providers/hashicorp/cloudinit/latest/docs/data-sources/config) | data source |
 
 ## Inputs

--- a/nomad-aws/README.md
+++ b/nomad-aws/README.md
@@ -80,9 +80,9 @@ There are more examples in the [examples](./examples/) directory.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.98.0 |
-| <a name="provider_cloudinit"></a> [cloudinit](#provider\_cloudinit) | 2.3.7 |
-| <a name="provider_random"></a> [random](#provider\_random) | 3.7.2 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5 |
+| <a name="provider_cloudinit"></a> [cloudinit](#provider\_cloudinit) | >=2.3 |
+| <a name="provider_random"></a> [random](#provider\_random) | n/a |
 
 ## Modules
 

--- a/nomad-aws/main.tf
+++ b/nomad-aws/main.tf
@@ -30,6 +30,10 @@ data "aws_ami" "ubuntu_focal" {
   owners = var.machine_image_owners
 }
 
+data "aws_vpc" "nomad" {
+  id = var.vpc_id
+}
+
 module "nomad_tls" {
   source                = "../shared/modules/tls"
   nomad_server_hostname = local.nomad_host_name_if_server
@@ -42,6 +46,7 @@ locals {
   # Will include SSH SG if var.ssh_key is not null.
   nomad_security_groups = compact([
     aws_security_group.nomad_sg.id,
+    aws_security_group.nomad_traffic_sg.id,
     var.ssh_key != null ? aws_security_group.ssh_sg[0].id : "",
   ])
 }

--- a/nomad-aws/security_groups.tf
+++ b/nomad-aws/security_groups.tf
@@ -20,6 +20,28 @@ resource "aws_security_group" "nomad_sg" {
   }
 }
 
+resource "aws_security_group" "nomad_traffic_sg" {
+  name        = "${var.basename}-nomad_traffic_sg"
+  description = "Security group that restrict Nomad Client Server communication within VPC CIDR"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    description = "Allow CircleCI Nomad traffic within VPC"
+    from_port   = 4646
+    to_port     = 4648
+    protocol    = "tcp"
+    cidr_blocks = data.aws_vpc.nomad.cidr_block
+  }
+
+  egress {
+    description = "Allow CircleCI Nomad outbound connections"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"] # tfsec:ignore:aws-vpc-no-public-egress-sgr
+  }
+}
+
 resource "aws_security_group" "ssh_sg" {
   description = "Security group that permits CircleCI Server to SSH into nomad instances"
   count       = var.ssh_key != null ? 1 : 0


### PR DESCRIPTION
:gear: **Issue**
There is no explicit security group rule defined for Nomad Client in AWS provider. 

:white_check_mark: **Fix**
Added Explicit SG rule which allow Nomad Server/Client communication within VPC. This will safe keep the Nomad Clients from any external connection attempts. 
