### PR TITLE
ONPREM-2268 | Enable mTLS for http for Nomad Client and Server

### DIFF
--- a/nomad-aws/modules/nomad-server-aws/templates/nomad-server-startup.sh.tpl
+++ b/nomad-aws/modules/nomad-server-aws/templates/nomad-server-startup.sh.tpl
@@ -94,7 +94,7 @@ EOT
 if [ "${tls_cert}" ]; then
 cat <<-EOT >> /etc/nomad/server.hcl
 tls {
-    http = false
+    http = true
     rpc  = true
     # This verifies the CN ([role].[region].nomad) in the certificate,
     # not the hostname or DNS name of the of the remote party.

--- a/nomad-aws/template/nomad-startup.sh.tpl
+++ b/nomad-aws/template/nomad-startup.sh.tpl
@@ -140,7 +140,7 @@ EOT
 if [ "${client_tls_cert}" ]; then
 cat <<EOT >> /etc/nomad/client.hcl
 tls {
-http = false
+    http = true
     rpc  = true
      # This verifies the CN ([role].[region].nomad) in the certificate,
     # not the hostname or DNS name of the of the remote party.

--- a/nomad-gcp/modules/nomad-server-gcp/templates/nomad-server-startup.sh.tpl
+++ b/nomad-gcp/modules/nomad-server-gcp/templates/nomad-server-startup.sh.tpl
@@ -121,7 +121,7 @@ configure_nomad() {
 	if [ "${tls_cert}" ]; then
 		cat <<-EOT >> /etc/nomad/config.hcl
 		tls {
-		  http = false
+		  http = true
 		  rpc  = true
 		  # This verifies the CN ([role].[region].nomad) in the certificate,
 		  # not the hostname or DNS name of the of the remote party.

--- a/nomad-gcp/templates/nomad-startup.sh.tpl
+++ b/nomad-gcp/templates/nomad-startup.sh.tpl
@@ -156,7 +156,7 @@ configure_nomad() {
 	if [ "${client_tls_cert}" ]; then
 		cat <<-EOT >> /etc/nomad/config.hcl
 		tls {
-		  http = false
+		  http = true
 		  rpc  = true
 		  # This verifies the CN ([role].[region].nomad) in the certificate,
 		  # not the hostname or DNS name of the of the remote party.


### PR DESCRIPTION
:gear: **Issue**
- mTLS is not enabled for http protocol

:white_check_mark: **Fix**
- set the mTLS for http  `true` 

