### PR TITLE
ONPREM-2249 | typo fix added []

### DIFF
--- a/nomad-aws/security_groups.tf
+++ b/nomad-aws/security_groups.tf
@@ -30,7 +30,7 @@ resource "aws_security_group" "nomad_traffic_sg" {
     from_port   = 4646
     to_port     = 4648
     protocol    = "tcp"
-    cidr_blocks = data.aws_vpc.nomad.cidr_block
+    cidr_blocks = [data.aws_vpc.nomad.cidr_block]
   }
 
   egress {


### PR DESCRIPTION
Added missing `[]` in AWS Security Group IAM for Nomad