### PR TITLE
Add GovCloud Nomad image owner to nomad-aws/variables.tf

### DIFF
--- a/nomad-aws/README.md
+++ b/nomad-aws/README.md
@@ -141,7 +141,7 @@ There are more examples in the [examples](./examples/) directory.
 | <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | AWS Node type for instance. Must be Intel linux type | `string` | `"t3.2xlarge"` | no |
 | <a name="input_launch_template_version"></a> [launch\_template\_version](#input\_launch\_template\_version) | Specific version of the instance template | `string` | `"$Latest"` | no |
 | <a name="input_machine_image_names"></a> [machine\_image\_names](#input\_machine\_image\_names) | Strings to filter image names for nomad virtual machine images. | `list(string)` | <pre>[<br/>  "CircleCIServerNomad*"<br/>]</pre> | no |
-| <a name="input_machine_image_owners"></a> [machine\_image\_owners](#input\_machine\_image\_owners) | List of AWS account IDs that own the images to be used for nomad virtual machines. | `list(string)` | <pre>[<br/>  "833371238208"<br/>]</pre> | no |
+| <a name="input_machine_image_owners"></a> [machine\_image\_owners](#input\_machine\_image\_owners) | List of AWS account IDs that own the images to be used for nomad virtual machines. | `list(string)` | <pre>[<br/>  "833371238208",<br/>  "535726571669"<br/>]</pre> | no |
 | <a name="input_max_nodes"></a> [max\_nodes](#input\_max\_nodes) | Maximum number of nomad clients to create. Must be greater than or equal to nodes | `number` | `5` | no |
 | <a name="input_max_server_replicas"></a> [max\_server\_replicas](#input\_max\_server\_replicas) | Maximum number of Nomad Server instances | `number` | `7` | no |
 | <a name="input_nodes"></a> [nodes](#input\_nodes) | Desired Number of nomad clients to create | `number` | n/a | yes |

--- a/nomad-aws/variables.tf
+++ b/nomad-aws/variables.tf
@@ -176,7 +176,7 @@ locals {
 variable "machine_image_owners" {
   type        = list(string)
   description = "List of AWS account IDs that own the images to be used for nomad virtual machines."
-  default     = ["833371238208"]
+  default     = ["833371238208", "535726571669"]
 }
 
 variable "machine_image_names" {


### PR DESCRIPTION
In #223, we on updated the machine_image_owners in nomad-aws/modules/nomad-server-aws/variables.tf. However, this default will get overwritten here when the nomad-aws Terraform is applied: https://github.com/CircleCI-Public/server-terraform/blob/0b896690b95deb4cad901a3359847540961bc773/nomad-aws/server.tf#L29. Therefore, we should set this default in the top-level variables.

:gear: **Issue**

<!-- What's wrong; why the change? A good place to reference the ticket if it exists. -->

:white_check_mark: **Fix**

<!-- How did you fix the issue? -->

:question: **Tests**

<!-- Enumerate what you tested here. We 💖 screenshots and issue specific tests!-->

- [ ] Passed _reality check_
