### PR TITLE
WIP | ONPREM-2284 | nomad-gcp | update nomad tags for gcp

### DIFF
--- a/nomad-gcp/firewall.tf
+++ b/nomad-gcp/firewall.tf
@@ -47,7 +47,6 @@ resource "google_compute_firewall" "nomad-traffic" {
   }
 
   source_ranges = [data.google_compute_subnetwork.nomad.ip_cidr_range] #tfsec:ignore:google-compute-no-public-ingress
-  target_tags   = local.tags
 }
 
 resource "google_compute_firewall" "nomad-ssh" {

--- a/nomad-gcp/main.tf
+++ b/nomad-gcp/main.tf
@@ -1,7 +1,7 @@
 locals {
   nomad_server_hostname_and_port = "${var.nomad_server_hostname}:${var.nomad_server_port}"
   server_retry_join              = "provider=gce project_name=${var.project_id} zone_pattern=${var.zone} tag_value=circleci-${var.name}-nomad-servers"
-  tags                           = ["nomad", "circleci-server", "${var.name}-nomad-clients"]
+  tags                           = ["circleci-nomad-clients", "${var.name}-nomad-clients"]
 }
 
 data "google_compute_subnetwork" "nomad" {

--- a/nomad-gcp/modules/nomad-server-gcp/firewall.tf
+++ b/nomad-gcp/modules/nomad-server-gcp/firewall.tf
@@ -26,5 +26,4 @@ resource "google_compute_firewall" "nomad" {
   }
 
   source_ranges = [data.google_compute_subnetwork.nomad.ip_cidr_range] #tfsec:ignore:google-compute-no-public-ingress
-  target_tags   = local.tags
 }

--- a/nomad-gcp/modules/nomad-server-gcp/server.tf
+++ b/nomad-gcp/modules/nomad-server-gcp/server.tf
@@ -9,7 +9,7 @@ data "google_compute_subnetwork" "nomad" {
 }
 
 locals {
-  tags = ["nomad-server", "circleci-nomad-server", "${var.name}-nomad-servers", "nomad"]
+  tags = ["circleci-nomad-server", "${var.name}-nomad-servers"]
 }
 
 resource "google_compute_autoscaler" "nomad" {


### PR DESCRIPTION
Streamlined the tagging for Nomad in GCP. 

Nomad Clients will be tagged as - `"circleci-nomad-clients", "${var.name}-nomad-clients"`
and
Server as - `"circleci-nomad-server", "${var.name}-nomad-servers"`