### PR TITLE
ONPREM-2370 | Using token while calling Metadata endpoint

### DIFF
--- a/nomad-aws/examples/irsa/main.tf
+++ b/nomad-aws/examples/irsa/main.tf
@@ -16,7 +16,8 @@ provider "aws" {
 # server in a preexisting VPC and want your nomad clients to run there,
 # In that case, you should make the appropriate changes in this file.
 module "vpc" {
-  source = "terraform-aws-modules/vpc/aws"
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "~> 5.21.0"
 
   name                 = "nomad-vpc"
   cidr                 = "192.168.0.0/16"


### PR DESCRIPTION
:gear: **Issue**
Rerun with SSH functionality has been broke when forcing **IMDSv2 on Nomad clients**, getting below error - 

<img width="1509" height="268" alt="image" src="https://github.com/user-attachments/assets/c8af16d5-8dc6-4980-9e00-c1606da1baef" />

:white_check_mark: **Fix**
- Added the token while calling metadata end points

- [X] Passed _reality check_
