### PR TITLE
ONPREM-2273 | Remove option to disable mtls in GCP Nomad

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,13 @@ format:
 .PHONY: test
 test:
 	@make tfsec
+	@make tftest-gcp
 
 .PHONY: tfsec
 tfsec:
 	@tfsec .
+
+.PHONY: tftest-gcp
+tftest-gcp:
+	@export GOOGLE_PROJECT="dummy-project" GOOGLE_CREDENTIALS='{"type": "service_account"}'
+	@cd nomad-gcp && terraform init -backend=false && terraform test

--- a/nomad-gcp/README.md
+++ b/nomad-gcp/README.md
@@ -125,7 +125,6 @@ There are more examples in the [examples](./examples/) directory.
 | <a name="input_server_target_cpu_utilization"></a> [server\_target\_cpu\_utilization](#input\_server\_target\_cpu\_utilization) | Target CPU utilization to trigger autoscaling for nomad server cluster | `number` | `0.8` | no |
 | <a name="input_subnetwork"></a> [subnetwork](#input\_subnetwork) | Subnetwork to deploy nomad clients into. NB. This is required if using custom subnets | `string` | `""` | no |
 | <a name="input_target_cpu_utilization"></a> [target\_cpu\_utilization](#input\_target\_cpu\_utilization) | Target CPU utilization to trigger autoscaling | `number` | `0.5` | no |
-| <a name="input_unsafe_disable_mtls"></a> [unsafe\_disable\_mtls](#input\_unsafe\_disable\_mtls) | Disables mTLS between nomad client and servers. Compromises the authenticity and confidentiality of client-server communication. Should not be set to true in any production setting | `bool` | `false` | no |
 | <a name="input_zone"></a> [zone](#input\_zone) | GCP compute zone to deploy nomad clients into (e.g us-east1-a) | `string` | n/a | yes |
 
 ## Outputs

--- a/nomad-gcp/examples/basic/main.tf
+++ b/nomad-gcp/examples/basic/main.tf
@@ -91,7 +91,6 @@ module "nomad" {
   nomad_server_hostname = var.nomad_server_hostname
   machine_type          = var.machine_type
 
-  unsafe_disable_mtls    = false
   assign_public_ip       = true
   preemptible            = true
   target_cpu_utilization = 0.50

--- a/nomad-gcp/examples/docker_network/main.tf
+++ b/nomad-gcp/examples/docker_network/main.tf
@@ -107,7 +107,6 @@ module "nomad" {
   machine_type          = var.machine_type
   docker_network_cidr   = var.docker_network_cidr
 
-  unsafe_disable_mtls    = false
   assign_public_ip       = true
   preemptible            = true
   target_cpu_utilization = 0.50

--- a/nomad-gcp/examples/nomad-server/main.tf
+++ b/nomad-gcp/examples/nomad-server/main.tf
@@ -75,7 +75,6 @@ module "nomad" {
   machine_type          = var.machine_type
   project_id            = var.project
 
-  unsafe_disable_mtls    = false
   assign_public_ip       = true
   preemptible            = true
   target_cpu_utilization = 0.50

--- a/nomad-gcp/main.tf
+++ b/nomad-gcp/main.tf
@@ -14,7 +14,6 @@ module "tls" {
   source                = "./../shared/modules/tls"
   nomad_server_hostname = var.nomad_server_hostname
   nomad_server_port     = var.nomad_server_port
-  count                 = var.unsafe_disable_mtls ? 0 : 1
 }
 
 resource "google_compute_autoscaler" "nomad" {
@@ -89,9 +88,9 @@ resource "google_compute_instance_template" "nomad" {
       nomad_version       = var.nomad_version
       add_server_join     = var.add_server_join ? var.add_server_join : ""
       blocked_cidrs       = var.blocked_cidrs
-      client_tls_cert     = var.unsafe_disable_mtls ? "" : module.tls[0].nomad_client_cert
-      client_tls_key      = var.unsafe_disable_mtls ? "" : module.tls[0].nomad_client_key
-      tls_ca              = var.unsafe_disable_mtls ? "" : module.tls[0].nomad_tls_ca
+      client_tls_cert     = module.tls.nomad_client_cert
+      client_tls_key      = module.tls.nomad_client_key
+      tls_ca              = module.tls.nomad_tls_ca
       docker_network_cidr = var.docker_network_cidr
       server_retry_join   = var.deploy_nomad_server_instances ? local.server_retry_join : local.nomad_server_hostname_and_port
     }

--- a/nomad-gcp/output.tf
+++ b/nomad-gcp/output.tf
@@ -1,28 +1,28 @@
 output "nomad_server_tls_cert" {
-  value = var.unsafe_disable_mtls ? "" : module.tls[0].nomad_server_cert
+  value = module.tls.nomad_server_cert
 }
 
 output "nomad_server_tls_key" {
-  value = var.unsafe_disable_mtls ? "" : nonsensitive(module.tls[0].nomad_server_key)
+  value = nonsensitive(module.tls.nomad_server_key)
 }
 
 output "nomad_tls_ca" {
-  value = var.unsafe_disable_mtls ? "" : module.tls[0].nomad_tls_ca
+  value = module.tls.nomad_tls_ca
 }
 
 output "nomad_server_tls_cert_base64" {
   description = "set this value for the `nomad.server.rpc.mTLS.certificate` key in the CircleCI Server's Helm values.yaml"
-  value       = var.unsafe_disable_mtls ? "" : base64encode(module.tls[0].nomad_server_cert)
+  value       = base64encode(module.tls.nomad_server_cert)
 }
 
 output "nomad_server_tls_key_base64" {
   description = "set this value for the `nomad.server.rpc.mTLS.privateKey` key in the CircleCI Server's Helm values.yaml"
-  value       = var.unsafe_disable_mtls ? "" : nonsensitive(base64encode(module.tls[0].nomad_server_key))
+  value       = nonsensitive(base64encode(module.tls.nomad_server_key))
 }
 
 output "nomad_tls_ca_base64" {
   description = "set this value for the `nomad.server.rpc.mTLS.CACertificate` key in the CircleCI Server's Helm values.yaml"
-  value       = var.unsafe_disable_mtls ? "" : base64encode(module.tls[0].nomad_tls_ca)
+  value       = base64encode(module.tls.nomad_tls_ca)
 }
 
 

--- a/nomad-gcp/servers.tf
+++ b/nomad-gcp/servers.tf
@@ -18,9 +18,9 @@ module "server" {
   nomad_server_hostname            = var.nomad_server_hostname
   name                             = var.name
   project_id                       = var.project_id
-  tls_cert                         = var.unsafe_disable_mtls ? "" : module.tls[0].nomad_server_cert
-  tls_key                          = var.unsafe_disable_mtls ? "" : module.tls[0].nomad_server_key
-  tls_ca                           = var.unsafe_disable_mtls ? "" : module.tls[0].nomad_tls_ca
+  tls_cert                         = module.tls.nomad_server_cert
+  tls_key                          = module.tls.nomad_server_key
+  tls_ca                           = module.tls.nomad_tls_ca
   min_server_instances             = var.min_server_instances
   max_server_instances             = var.max_server_instances
   nomad_server_auto_scaling        = var.nomad_server_auto_scaling

--- a/nomad-gcp/tests/basic.tftest.hcl
+++ b/nomad-gcp/tests/basic.tftest.hcl
@@ -124,3 +124,30 @@ run "test_health_check_configuration" {
     error_message = "Health check should use correct Nomad health endpoint"
   }
 }
+
+run "test_mtls_configuration" {
+  variables {
+    region                = "canada-east1"
+    zone                  = "canada-east1-a"
+    nomad_server_hostname = "example.com"
+    min_replicas          = 2
+    max_replicas          = 8
+    name                  = "test-nomad"
+    machine_type          = "n2-standard-8"
+  }
+
+  assert {
+    condition     = module.tls.nomad_client_cert != ""
+    error_message = "Nomad Client cert should not be empty"
+  }
+
+  assert {
+    condition     = module.tls.nomad_client_key != ""
+    error_message = "Nomad Client key should not be empty"
+  }
+
+  assert {
+    condition     = module.tls.nomad_tls_ca != ""
+    error_message = "Nomad CA should not be empty"
+  }
+}

--- a/nomad-gcp/variables.tf
+++ b/nomad-gcp/variables.tf
@@ -26,12 +26,6 @@ variable "subnetwork" {
   description = "Subnetwork to deploy nomad clients into. NB. This is required if using custom subnets"
 }
 
-variable "unsafe_disable_mtls" {
-  type        = bool
-  default     = false
-  description = "Disables mTLS between nomad client and servers. Compromises the authenticity and confidentiality of client-server communication. Should not be set to true in any production setting"
-}
-
 variable "retry_with_ssh_allowed_cidr_blocks" {
   type        = list(string)
   default     = ["0.0.0.0/0"]


### PR DESCRIPTION
:gear: **Issue**
Currently, `nomad-gcp` give the options to disable the mTLS creation for nomad communication. 

:white_check_mark: **Fix**
- Removed the options to disable the mTLS, it will be forced generation
- Added Test for the same


