### PR TITLE
[ONPREM-3180] - Change ~> 5 to >= 5

### DIFF
--- a/nomad-aws/README.md
+++ b/nomad-aws/README.md
@@ -73,14 +73,14 @@ There are more examples in the [examples](./examples/) directory.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
 | <a name="requirement_cloudinit"></a> [cloudinit](#requirement\_cloudinit) | >=2.3 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
 | <a name="provider_cloudinit"></a> [cloudinit](#provider\_cloudinit) | >=2.3 |
 | <a name="provider_random"></a> [random](#provider\_random) | n/a |
 

--- a/nomad-aws/modules/nomad-server-aws/provider.tf
+++ b/nomad-aws/modules/nomad-server-aws/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5"
+      version = ">=5"
     }
     cloudinit = {
       source  = "hashicorp/cloudinit"

--- a/nomad-aws/versions.tf
+++ b/nomad-aws/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5"
+      version = ">= 5.0"
       source  = "hashicorp/aws"
     }
     cloudinit = {


### PR DESCRIPTION
:gear: **Issue**
https://circleci.atlassian.net/browse/ONPREM-3180

<!-- What's wrong; why the change? A good place to reference the ticket if it exists. -->
Server Terraform <4.7 required `>=3.0` for the AWS module. 4.8 and 4.9 introduced `~>5.0` which breaks deploys done if your module was >6.x.

:white_check_mark: **Fix**

<!-- How did you fix the issue? -->
I've tested this locally and everything deploys as normal when using 6.x

:question: **Tests**

<!-- Enumerate what you tested here. We 💖 screenshots and issue specific tests!-->

- [ ] Passed _reality check_
