### PR TITLE
ONPREM-3203 | Forcing dpkg lock to release

### DIFF
--- a/nomad-aws/template/nomad-startup.sh.tpl
+++ b/nomad-aws/template/nomad-startup.sh.tpl
@@ -62,6 +62,12 @@ fi
 echo "-------------------------------------------"
 echo "     Performing System Updates"
 echo "-------------------------------------------"
+# Stop unattended-upgrades and wait for dpkg lock to avoid conflicts on first boot
+systemctl stop unattended-upgrades 2>/dev/null || true
+while ! flock -n /var/lib/dpkg/lock-frontend -c true 2>/dev/null; do
+    echo "Waiting for dpkg lock to be released..."
+    sleep 10
+done
 apt-get update && retry apt-get -y upgrade
 
 echo "--------------------------------------"

--- a/nomad-gcp/templates/nomad-startup.sh.tpl
+++ b/nomad-gcp/templates/nomad-startup.sh.tpl
@@ -29,6 +29,12 @@ system_update() {
 	log "--------------------------------------"
 	log "Updating system"
 	log "--------------------------------------"
+	# Stop unattended-upgrades and wait for dpkg lock to avoid conflicts on first boot
+	systemctl stop unattended-upgrades 2>/dev/null || true
+	while ! flock -n /var/lib/dpkg/lock-frontend -c true 2>/dev/null; do
+		echo "Waiting for dpkg lock to be released..."
+		sleep 10
+	done
 	apt-get update && apt-get -y upgrade
 }
 


### PR DESCRIPTION
:gear: **Issue**
`unattended-upgrades` creates a lock on dpkg file which blocks the further software installation which throws error like below - 

```
Fetched 24.3 MB in 2min 24s (169 kB/s)
Reading package lists...
E: Could not get lock /var/lib/dpkg/lock-frontend. It is held by process 1719 (unattended-upgr)
E: Unable to acquire the dpkg frontend lock (/var/lib/dpkg/lock-frontend), is another process using it?
Attempt 1 failed! Trying again in 5s... (1/5)
```

:white_check_mark: **Fix**
- We are stopping the cron service `unattended-upgrades` which will release the lock file


