### PR TITLE
ONPREM-2514 | AWS - Added support for existing ssh key

### DIFF
--- a/nomad-aws/README.md
+++ b/nomad-aws/README.md
@@ -50,7 +50,12 @@ module "nomad" {
   # for more info, visit - https://docs.aws.amazon.com/eks/latest/userguide/associate-service-account-role.html
   enable_irsa = {}
 
+  # Option 1: provide a public key and terraform will create a new AWS Key Pair
   ssh_key = "<< public key to be placed on each nomad client >>"
+
+  # Option 2: use a pre-existing AWS Key Pair by name (mutually exclusive with ssh_key)
+  # ssh_key_name = "<< name of existing AWS Key Pair >>"
+
   basename = "<< name prefix for nomad clients >>"
 
   enable_imdsv2 = "<< optional/required >>"
@@ -170,7 +175,8 @@ There are more examples in the [examples](./examples/) directory.
 | <a name="input_server_disk_size_gb"></a> [server\_disk\_size\_gb](#input\_server\_disk\_size\_gb) | Disk size for nomad server instances | `number` | `20` | no |
 | <a name="input_server_machine_type"></a> [server\_machine\_type](#input\_server\_machine\_type) | The instance type of the EC2 Nomad Servers. | `string` | `"t3a.medium"` | no |
 | <a name="input_server_public_ip"></a> [server\_public\_ip](#input\_server\_public\_ip) | Should the Nomad Server EC2 instances have a public IP? | `bool` | `false` | no |
-| <a name="input_ssh_key"></a> [ssh\_key](#input\_ssh\_key) | SSH Public key to access nomad nodes. Both clients and servers when deployed | `string` | `null` | no |
+| <a name="input_ssh_key"></a> [ssh\_key](#input\_ssh\_key) | SSH Public key to access nomad nodes. Both clients and servers when deployed. Mutually exclusive with ssh\_key\_name. | `string` | `null` | no |
+| <a name="input_ssh_key_name"></a> [ssh\_key\_name](#input\_ssh\_key\_name) | Name of a pre-existing AWS Key Pair to use for nomad nodes. Mutually exclusive with ssh\_key. | `string` | `null` | no |
 | <a name="input_subnet"></a> [subnet](#input\_subnet) | Subnet ID | `string` | `""` | no |
 | <a name="input_subnets"></a> [subnets](#input\_subnets) | Subnet IDs | `list(string)` | <pre>[<br/>  ""<br/>]</pre> | no |
 | <a name="input_use_podman"></a> [use\_podman](#input\_use\_podman) | Use podman as the container runtime instead of Docker. Requires a podman-compatible AMI (cgroupv2). | `bool` | `false` | no |

--- a/nomad-aws/main.tf
+++ b/nomad-aws/main.tf
@@ -92,7 +92,7 @@ resource "aws_launch_template" "nomad_clients" {
   name_prefix   = "${var.basename}-nomad-clients-"
   instance_type = var.instance_type
   image_id      = var.use_podman ? data.aws_ami.ubuntu_podman[0].id : data.aws_ami.ubuntu_focal.id
-  key_name      = var.ssh_key != null ? aws_key_pair.ssh_key[0].id : null
+  key_name      = var.ssh_key_name != null ? var.ssh_key_name : (var.ssh_key != null ? aws_key_pair.ssh_key[0].id : null)
 
   network_interfaces {
     associate_public_ip_address = var.client_public_ip

--- a/nomad-aws/modules/nomad-server-aws/server.tf
+++ b/nomad-aws/modules/nomad-server-aws/server.tf
@@ -25,7 +25,7 @@ resource "aws_launch_template" "nomad-servers" {
   tags                   = local.tags
   user_data              = data.cloudinit_config.nomad_server_user_data.rendered
   update_default_version = true
-  key_name               = var.ssh_key != null ? aws_key_pair.ssh_key[0].id : null
+  key_name               = var.ssh_key_name != null ? var.ssh_key_name : (var.ssh_key != null ? aws_key_pair.ssh_key[0].id : null)
   metadata_options {
     http_tokens = var.enable_imdsv2
   }

--- a/nomad-aws/modules/nomad-server-aws/variables.tf
+++ b/nomad-aws/modules/nomad-server-aws/variables.tf
@@ -45,7 +45,13 @@ variable "launch_template_instance_type" {
 
 variable "ssh_key" {
   type        = string
-  description = "The SSH key you'd like to be on the Nomad Server instances."
+  description = "The SSH key you'd like to be on the Nomad Server instances. Mutually exclusive with ssh_key_name."
+  default     = null
+}
+
+variable "ssh_key_name" {
+  type        = string
+  description = "Name of a pre-existing AWS Key Pair to use for Nomad Server instances. Mutually exclusive with ssh_key."
   default     = null
 }
 

--- a/nomad-aws/security_groups.tf
+++ b/nomad-aws/security_groups.tf
@@ -45,7 +45,7 @@ resource "aws_security_group_rule" "nomad_traffic_sg" {
 
 
 resource "aws_security_group_rule" "nomad_ssh_sg" {
-  count             = var.ssh_key != null ? 1 : 0
+  count             = (var.ssh_key != null || var.ssh_key_name != null) ? 1 : 0
   description       = "Allow CircleCI Server to SSH into nomad instances"
   security_group_id = aws_security_group.nomad_sg.id
   type              = "ingress"

--- a/nomad-aws/server.tf
+++ b/nomad-aws/server.tf
@@ -21,6 +21,7 @@ module "server" {
   launch_template_instance_type = var.server_machine_type
   tags                          = var.instance_tags
   ssh_key                       = var.ssh_key
+  ssh_key_name                  = var.ssh_key_name
   public_ip                     = var.server_public_ip
   random_string_suffix          = random_string.key_suffix.result
   launch_template_version       = var.launch_template_version

--- a/nomad-aws/variables.tf
+++ b/nomad-aws/variables.tf
@@ -87,7 +87,13 @@ variable "instance_type" {
 
 variable "ssh_key" {
   type        = string
-  description = "SSH Public key to access nomad nodes. Both clients and servers when deployed"
+  description = "SSH Public key to access nomad nodes. Both clients and servers when deployed. Mutually exclusive with ssh_key_name."
+  default     = null
+}
+
+variable "ssh_key_name" {
+  type        = string
+  description = "Name of a pre-existing AWS Key Pair to use for nomad nodes. Mutually exclusive with ssh_key."
   default     = null
 }
 


### PR DESCRIPTION
:gear: **Issue**
- Customer can not use an existing ssh key residing in AWS

:white_check_mark: **Fix**
- Added support for Existing SSH key `ssh_key_name` which is mutually exclusive with `ssh_key`


