### PR TITLE
ONPREM-3277 | Adding Nomad Liveness check in GCP 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,7 +107,7 @@ jobs:
           name: Check if docs need to be updated
           command: |
             set +eo pipefail
-            git diff --quiet nomad-aws/README.md nomad-gcp/README.md
+            git diff nomad-aws/README.md nomad-gcp/README.md
             if [ $? -ne 0 ]; then
               echo "There have been docs changes. Please run the 'make docs' command locally."
               exit 1

--- a/nomad-gcp/README.md
+++ b/nomad-gcp/README.md
@@ -45,8 +45,8 @@ There are more examples in the [examples](./examples/) directory.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | ~> 5.0 |
-| <a name="provider_local"></a> [local](#provider\_local) | n/a |
+| <a name="provider_google"></a> [google](#provider\_google) | 7.9.0 |
+| <a name="provider_local"></a> [local](#provider\_local) | 2.5.3 |
 
 ## Modules
 
@@ -88,7 +88,7 @@ There are more examples in the [examples](./examples/) directory.
 | <a name="input_allowed_ips_nomad_ssh_access"></a> [allowed\_ips\_nomad\_ssh\_access](#input\_allowed\_ips\_nomad\_ssh\_access) | List of IPv4 CIDR ranges that are permitted SSH access nomad clients nodes | `list(string)` | <pre>[<br/>  "35.235.240.0/20"<br/>]</pre> | no |
 | <a name="input_apt_retry_max_attempts"></a> [apt\_retry\_max\_attempts](#input\_apt\_retry\_max\_attempts) | Maximum number of retry attempts for apt-get commands during startup. Each attempt waits 5 seconds. | `number` | `5` | no |
 | <a name="input_assign_public_ip"></a> [assign\_public\_ip](#input\_assign\_public\_ip) | Assign public IP | `bool` | `true` | no |
-| <a name="input_autoscaling_mode"></a> [autoscaling\_mode](#input\_autoscaling\_mode) | Autoscaler mode. Can be<br/>- "ON": Autoscaler will scale up and down to reach cpu target and react to cron schedules<br/>- "OFF": Autoscaler will never scale up or down<br/>- "ONLY\_SCALE\_OUT": Autoscaler will only scale out (default)<br/>Warning: jobs may be interrupted on scale down. Only select "ON" if<br/>interruptions are acceptible for your use case. | `string` | `"ONLY_SCALE_OUT"` | no |
+| <a name="input_autoscaling_mode"></a> [autoscaling\_mode](#input\_autoscaling\_mode) | Autoscaler mode. Can be<br/>- "ON": Autoscaler will scale up and down to reach cpu target and react to cron schedules<br/>- "OFF": Autoscaler will never scale up or down<br/>- "ONLY\_SCALE\_OUT": Autoscaler will only scale out (default)<br/>Warning: jobs may be interrupted on scale down. Only select "ON" if<br/>interruptions are acceptible for your use case. | `string` | `"ON"` | no |
 | <a name="input_autoscaling_schedules"></a> [autoscaling\_schedules](#input\_autoscaling\_schedules) | Autoscaler scaling schedules. Accepts the same arguments are documented<br/>upstream here: https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_autoscaler#scaling_schedules | <pre>list(object({<br/>    name                  = string<br/>    min_required_replicas = number<br/>    schedule              = string<br/>    time_zone             = string<br/>    duration_sec          = number<br/>    disabled              = bool<br/>    description           = string<br/>  }))</pre> | `[]` | no |
 | <a name="input_blocked_cidrs"></a> [blocked\_cidrs](#input\_blocked\_cidrs) | List of CIDR blocks to block access to from inside nomad jobs | `list(string)` | `[]` | no |
 | <a name="input_custom_ca_cert"></a> [custom\_ca\_cert](#input\_custom\_ca\_cert) | Custom CA certificate (PEM format) to install on Nomad client hosts.<br/>This CA will be added to the system trust store, allowing Docker or Podman to pull<br/>images from registries that use certificates signed by this CA.<br/>This is useful for environments with corporate proxies or private registries<br/>that use custom/self-signed certificates. | `string` | `""` | no |

--- a/nomad-gcp/main.tf
+++ b/nomad-gcp/main.tf
@@ -115,6 +115,8 @@ resource "google_compute_instance_template" "nomad" {
       podman_cpu_quota_percent = var.podman_cpu_quota_percent
       podman_tasks_max         = var.podman_tasks_max
       custom_ca_cert           = var.custom_ca_cert
+      set_unhealthy_script     = base64encode(file("${path.module}/templates/nomad-set-unhealthy.sh"))
+      liveness_check_script    = base64encode(templatefile("${path.module}/templates/nomad-liveness-check.sh.tpl", { external_nomad_server = var.deploy_nomad_server_instances, use_podman = var.use_podman }))
     }
   )
 
@@ -150,7 +152,7 @@ resource "google_compute_instance_template" "nomad" {
   service_account {
     # https://developers.google.com/identity/protocols/googlescopes
     scopes = [
-      "https://www.googleapis.com/auth/compute.readonly",
+      "https://www.googleapis.com/auth/compute",
       "https://www.googleapis.com/auth/logging.write",
     ]
   }

--- a/nomad-gcp/templates/nomad-liveness-check.sh.tpl
+++ b/nomad-gcp/templates/nomad-liveness-check.sh.tpl
@@ -1,0 +1,107 @@
+#!/bin/bash
+MAX_FAILURES=5
+MAX_RESTARTS=5
+CHECK_INTERVAL=30
+FAILURE_COUNT=0
+RESTART_COUNT=0
+LAST_LEADER=""
+
+log() {
+    echo "$(date -u '+%Y-%m-%dT%H:%M:%SZ') [nomad-liveness-check] $*" | tee -a /var/log/nomad-liveness-check.log
+}
+
+get_instance_name() {
+    curl -sf -H "Metadata-Flavor: Google" \
+        "http://metadata.google.internal/computeMetadata/v1/instance/name" 2>/dev/null
+}
+
+check_nomad_installed() {
+    [ -x /usr/bin/nomad ] && systemctl is-active --quiet nomad
+}
+
+mark_unhealthy() {
+    log "$1 — marking instance for recreation in MIG"
+    if /usr/local/bin/nomad-set-unhealthy.sh "$GCP_INSTANCE_NAME" 2>/dev/null; then
+        log "Instance $GCP_INSTANCE_NAME marked for recreation in MIG"
+    else
+        log "Failed to mark instance for recreation (no service account or not in a MIG)"
+    fi
+    sleep 600
+}
+
+check_container_runtime() {
+%{ if use_podman ~}
+    [ -x /usr/bin/podman ] && systemctl is-active --quiet podman
+%{ else ~}
+    [ -x /usr/bin/docker ] && systemctl is-active --quiet docker
+%{ endif ~}
+}
+
+check_server_reachable() {
+    local leader
+%{ if external_nomad_server ~}
+    leader=$(curl -sf --max-time 10 \
+        --cacert /etc/ssl/nomad/ca.pem \
+        --cert /etc/ssl/nomad/client.pem \
+        --key /etc/ssl/nomad/key.pem \
+        "https://localhost:4646/v1/status/leader" 2>/dev/null | tr -d '"')
+%{ else ~}
+    leader=$(curl -sf --max-time 10 "http://localhost:4646/v1/status/leader" 2>/dev/null | tr -d '"')
+%{ endif ~}
+    if [ -n "$leader" ]; then
+        if [ "$leader" != "$LAST_LEADER" ]; then
+            log "Nomad server leader: $leader"
+            LAST_LEADER=$leader
+        fi
+        return 0
+    fi
+    return 1
+}
+
+GCP_INSTANCE_NAME=$(get_instance_name)
+log "Starting nomad liveness check (interval: $CHECK_INTERVAL s, max failures: $MAX_FAILURES, instance: $GCP_INSTANCE_NAME)"
+
+log "Waiting for installation to complete..."
+until [ -x /usr/bin/nomad ] || [ "$SECONDS" -gt 900 ]; do
+    sleep 30
+done
+log "Installation wait complete (elapsed: $${SECONDS}s)"
+
+while true; do
+    if ! check_nomad_installed; then
+        mark_unhealthy "Nomad binary missing or service not active"
+        FAILURE_COUNT=0
+        RESTART_COUNT=0
+        continue
+    fi
+
+    if ! check_container_runtime; then
+        mark_unhealthy "Container runtime missing or not active"
+        FAILURE_COUNT=0
+        RESTART_COUNT=0
+        continue
+    fi
+
+    if check_server_reachable; then
+        FAILURE_COUNT=0
+        RESTART_COUNT=0
+    else
+        FAILURE_COUNT=$((FAILURE_COUNT + 1))
+        log "Server unreachable (failure $FAILURE_COUNT/$MAX_FAILURES)"
+        if [ "$FAILURE_COUNT" -ge "$MAX_FAILURES" ]; then
+            if [ "$RESTART_COUNT" -ge "$MAX_RESTARTS" ]; then
+                mark_unhealthy "Nomad failed after $RESTART_COUNT restarts"
+                FAILURE_COUNT=0
+            else
+                RESTART_COUNT=$((RESTART_COUNT + 1))
+                log "Flushing DNS cache and restarting nomad (attempt $RESTART_COUNT/$MAX_RESTARTS)..."
+                resolvectl flush-caches
+                systemctl restart nomad
+                FAILURE_COUNT=0
+                log "Nomad restarted, waiting for stabilization"
+                sleep 120
+            fi
+        fi
+    fi
+    sleep $CHECK_INTERVAL
+done

--- a/nomad-gcp/templates/nomad-set-unhealthy.sh
+++ b/nomad-gcp/templates/nomad-set-unhealthy.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -euo pipefail
+INSTANCE_NAME=$1
+
+METADATA_URL="http://metadata.google.internal/computeMetadata/v1"
+METADATA_HEADER="Metadata-Flavor: Google"
+
+meta_get() {
+    curl -sf -H "$METADATA_HEADER" "$METADATA_URL/$1"
+}
+
+PROJECT=$(meta_get "project/project-id")
+ZONE=$(meta_get "instance/zone" | awk -F/ '{print $NF}')
+TOKEN=$(meta_get "instance/service-accounts/default/token" | jq -r '.access_token')
+
+CREATED_BY=$(meta_get "instance/attributes/created-by") || { echo "Failed to get created-by attribute" >&2; exit 1; }
+MIG_NAME=$(echo "$CREATED_BY" | awk -F/ '{print $NF}')
+
+if [ -z "$MIG_NAME" ]; then
+    echo "Could not determine MIG name for instance $INSTANCE_NAME" >&2
+    exit 1
+fi
+
+INSTANCE_URL="https://www.googleapis.com/compute/v1/projects/$PROJECT/zones/$ZONE/instances/$INSTANCE_NAME"
+
+curl -sf --max-time 10 -X POST \
+    -H "Authorization: Bearer $TOKEN" \
+    -H "Content-Type: application/json" \
+    "https://compute.googleapis.com/compute/v1/projects/$PROJECT/zones/$ZONE/instanceGroupManagers/$MIG_NAME/recreateInstances" \
+    -d "{\"instances\": [\"$INSTANCE_URL\"]}"

--- a/nomad-gcp/templates/nomad-startup.sh.tpl
+++ b/nomad-gcp/templates/nomad-startup.sh.tpl
@@ -158,6 +158,50 @@ configure_nomad() {
 	source /etc/environment
 	env | grep "NOMAD_"
 
+	echo "--------------------------------------"
+	echo "  Creating MIG health reporter"
+	echo "--------------------------------------"
+	echo "${set_unhealthy_script}" | base64 -d > /usr/local/bin/nomad-set-unhealthy.sh
+	chmod 0700 /usr/local/bin/nomad-set-unhealthy.sh
+
+	echo "--------------------------------------"
+	echo "  Creating nomad liveness check"
+	echo "--------------------------------------"
+	echo "${liveness_check_script}" | base64 -d > /usr/local/bin/nomad-liveness-check.sh
+	chmod 0700 /usr/local/bin/nomad-liveness-check.sh
+
+	cat <<-EOT > /etc/systemd/system/nomad-liveness-check.service
+	[Unit]
+	Description=Nomad client liveness check
+	After=network.target
+	[Service]
+	Type=simple
+	Restart=always
+	RestartSec=30
+	ExecStart=/usr/local/bin/nomad-liveness-check.sh
+	StandardOutput=journal
+	StandardError=journal
+	[Install]
+	WantedBy=multi-user.target
+	EOT
+
+	systemctl daemon-reload
+	systemctl enable --now nomad-liveness-check
+
+	echo "--------------------------------------"
+	echo "  Configuring log rotation"
+	echo "--------------------------------------"
+	cat <<-EOT > /etc/logrotate.d/nomad-liveness-check
+	/var/log/nomad-liveness-check.log {
+	    daily
+	    rotate 7
+	    compress
+	    missingok
+	    notifempty
+	    copytruncate
+	}
+	EOT
+
 	log "Setting nomad configuration"
 	mkdir -p /etc/nomad
 	cat <<-EOT > /etc/nomad/client.hcl
@@ -231,11 +275,23 @@ configure_nomad() {
 	fi
 	ls -l /etc/nomad/client.hcl
 
+	echo "--------------------------------------"
+	echo "  Disabling systemd-resolved DNS cache"
+	echo "--------------------------------------"
+	mkdir -p /etc/systemd/resolved.conf.d
+	cat <<-EOT > /etc/systemd/resolved.conf.d/no-cache.conf
+	[Resolve]
+	Cache=no
+	EOT
+	systemctl restart systemd-resolved
 
 	log "Writing nomad systemd unit"
 	cat <<-EOT > /etc/systemd/system/nomad.service
 	[Unit]
 	Description="nomad"
+	OnFailure=nomad-reconnect.service
+	StartLimitIntervalSec=300
+	StartLimitBurst=5
 	[Service]
 	Environment="NOMAD_CACERT=/etc/ssl/nomad/ca.pem"
 	Environment="NOMAD_CLIENT_CERT=/etc/ssl/nomad/client.pem"
@@ -253,6 +309,32 @@ configure_nomad() {
 	log "Starting up nomad"
 	echo "----------------------------------------------"
 	systemctl enable --now nomad
+
+	echo "--------------------------------------"
+	echo "  Creating nomad reconnect handler"
+	echo "--------------------------------------"
+	cat <<-EOT > /usr/local/bin/nomad-reconnect.sh
+	#!/bin/bash
+	log() {
+	    echo "\$(date -u '+%Y-%m-%dT%H:%M:%SZ') [nomad-reconnect] \$*" | tee -a /var/log/nomad-liveness-check.log
+	}
+	log "Nomad failed — flushing DNS cache and restarting"
+	resolvectl flush-caches
+	sleep 30
+	systemctl restart nomad.service
+	log "Nomad restarted"
+	EOT
+	chmod 0700 /usr/local/bin/nomad-reconnect.sh
+
+	cat <<-EOT > /etc/systemd/system/nomad-reconnect.service
+	[Unit]
+	Description=Nomad reconnect after failure
+	[Service]
+	Type=oneshot
+	ExecStart=/usr/local/bin/nomad-reconnect.sh
+	EOT
+
+	systemctl daemon-reload
 }
 
 create_ci_network() {

--- a/nomad-gcp/variables.tf
+++ b/nomad-gcp/variables.tf
@@ -89,7 +89,7 @@ variable "nomad_auto_scaler" {
 
 variable "autoscaling_mode" {
   type        = string
-  default     = "ONLY_SCALE_OUT"
+  default     = "ON"
   description = <<-EOF
     Autoscaler mode. Can be
     - "ON": Autoscaler will scale up and down to reach cpu target and react to cron schedules


### PR DESCRIPTION
- Same as #285 but for GCP nomad
- Added `nomad-set-unhealthy.sh` - this script is responsible to set status of Nomad Client as unhealthy if nomad-liveness-check.sh fails
- Added `nomad-liveness-check.sh` - this script detects if nomad/docker is installed and nomad-server is reachable, if not, it makes the liveness fail.
- Added these 2 scripts as systemd services `nomad-liveness-check`