### PR TITLE
Supporting additional sans and ips for certs

### DIFF
--- a/shared/modules/tls/main.tf
+++ b/shared/modules/tls/main.tf
@@ -57,17 +57,15 @@ resource "tls_cert_request" "nomad_client" {
     organization = "nomad:client"
   }
 
-  dns_names = [
+  dns_names = concat([
     "client.global.nomad",
     "localhost",
     "nomad-server",
     "nomad-server-*.global",
-    "${var.nomad_server_hostname}"
-  ]
+    var.nomad_server_hostname,
+  ], var.additional_dns_sans)
 
-  ip_addresses = [
-    "127.0.0.1",
-  ]
+  ip_addresses = concat(["127.0.0.1"], var.additional_ip_sans)
 }
 
 resource "tls_locally_signed_cert" "nomad_client" {
@@ -100,17 +98,15 @@ resource "tls_cert_request" "nomad_server" {
   }
 
 
-  dns_names = [
+  dns_names = concat([
     "server.global.nomad",
     "localhost",
     "nomad-server",
     "nomad-server-*.global",
-    "${var.nomad_server_hostname}"
-  ]
+    var.nomad_server_hostname,
+  ], var.additional_dns_sans)
 
-  ip_addresses = [
-    "127.0.0.1",
-  ]
+  ip_addresses = concat(["127.0.0.1"], var.additional_ip_sans)
 }
 
 resource "tls_locally_signed_cert" "nomad_server" {

--- a/shared/modules/tls/variables.tf
+++ b/shared/modules/tls/variables.tf
@@ -8,3 +8,15 @@ variable "nomad_server_port" {
   description = "Port that the nomad server endpoint listens on."
   default     = 4647
 }
+
+variable "additional_dns_sans" {
+  type        = list(string)
+  description = "Additional DNS SANs to include in the Nomad server and client certificates."
+  default     = []
+}
+
+variable "additional_ip_sans" {
+  type        = list(string)
+  description = "Additional IP SANs to include in the Nomad server and client certificates."
+  default     = []
+}


### PR DESCRIPTION
`main.tf` — update both `tls_cert_request.nomad_client` and `tls_cert_request.nomad_server` to concat() the hardcoded defaults with the new variables.

The hardcoded entries stay as-is; callers just pass extras when needed. 