### PR TITLE
ONP-301 | Added additonal healthcheck in aws nomad server like nomad clients

### DIFF
--- a/nomad-aws/modules/nomad-server-aws/role.tf
+++ b/nomad-aws/modules/nomad-server-aws/role.tf
@@ -1,6 +1,6 @@
 resource "aws_iam_policy" "describe_ec2_policy" {
   name        = "${var.basename}-circleci-nomad-server-role-policy"
-  description = "Policy to allow ec2:DescribeInstances"
+  description = "Policy to allow ec2:DescribeInstances and autoscaling:SetInstanceHealth"
 
   policy = jsonencode({
     Version = "2012-10-17"
@@ -8,6 +8,11 @@ resource "aws_iam_policy" "describe_ec2_policy" {
       {
         Effect   = "Allow"
         Action   = "ec2:DescribeInstances"
+        Resource = "*"
+      },
+      {
+        Effect   = "Allow"
+        Action   = "autoscaling:SetInstanceHealth"
         Resource = "*"
       }
     ]

--- a/nomad-aws/modules/nomad-server-aws/server.tf
+++ b/nomad-aws/modules/nomad-server-aws/server.tf
@@ -84,13 +84,15 @@ data "cloudinit_config" "nomad_server_user_data" {
     content_type = "text/x-shellscript"
     content = templatefile("${path.module}/templates/nomad-server-startup.sh.tpl",
       {
-        tls_cert          = var.tls_cert
-        tls_key           = var.tls_key
-        tls_ca            = var.tls_ca
-        bootstrap_expect  = var.desired_capacity
-        server_retry_join = var.server_retry_join
-        nomad_version     = var.nomad_version
-        log_level         = var.log_level
+        tls_cert              = var.tls_cert
+        tls_key               = var.tls_key
+        tls_ca                = var.tls_ca
+        bootstrap_expect      = var.desired_capacity
+        server_retry_join     = var.server_retry_join
+        nomad_version         = var.nomad_version
+        log_level             = var.log_level
+        set_unhealthy_script  = base64encode(file("${path.module}/templates/nomad-set-unhealthy.sh"))
+        liveness_check_script = base64encode(file("${path.module}/templates/nomad-server-liveness-check.sh"))
       }
     )
   }

--- a/nomad-aws/modules/nomad-server-aws/templates/nomad-server-liveness-check.sh
+++ b/nomad-aws/modules/nomad-server-aws/templates/nomad-server-liveness-check.sh
@@ -1,0 +1,136 @@
+#!/bin/bash
+MAX_FAILURES=5
+MAX_RESTARTS=5
+CHECK_INTERVAL=30
+FAILURE_COUNT=0
+RESTART_COUNT=0
+LAST_LEADER=""
+
+log() {
+  echo "$(date -u '+%Y-%m-%dT%H:%M:%SZ') [nomad-liveness-check] $*" | tee -a /var/log/nomad-liveness-check.log
+}
+
+get_instance_id() {
+  local token
+  token=$(curl -sf -X PUT "http://169.254.169.254/latest/api/token" \
+    -H "X-aws-ec2-metadata-token-ttl-seconds: 60" 2>/dev/null)
+  curl -sf -H "X-aws-ec2-metadata-token: $token" \
+    "http://169.254.169.254/latest/meta-data/instance-id" 2>/dev/null
+}
+
+get_local_ip() {
+  local token
+  token=$(curl -sf -X PUT "http://169.254.169.254/latest/api/token" \
+    -H "X-aws-ec2-metadata-token-ttl-seconds: 60" 2>/dev/null)
+  curl -sf -H "X-aws-ec2-metadata-token: $token" \
+    "http://169.254.169.254/latest/meta-data/local-ipv4" 2>/dev/null
+}
+
+check_nomad_installed() {
+  [ -x /usr/bin/nomad ] && systemctl is-active --quiet nomad
+}
+
+mark_unhealthy() {
+  log "$1 — marking instance unhealthy in ASG"
+  if /usr/local/bin/nomad-set-unhealthy.sh "$EC2_INSTANCE_ID" 2>/dev/null; then
+    log "Instance $EC2_INSTANCE_ID marked unhealthy in ASG"
+  else
+    log "Failed mark instance unhealthy (no IAM role or not in an ASG)"
+  fi
+  sleep 600
+}
+
+check_server_reachable() {
+  local leader
+  leader=$(curl -sf --max-time 10 \
+    --cacert /etc/ssl/nomad/ca.pem \
+    --cert /etc/ssl/nomad/server.pem \
+    --key /etc/ssl/nomad/key.pem \
+    https://localhost:4646/v1/status/leader 2>/dev/null) || return 1
+  if [ -z "$leader" ]; then
+    log "No leader elected — cluster may have lost quorum"
+    return 2
+  fi
+  if [ "$leader" != "$LAST_LEADER" ]; then
+    LAST_LEADER="$leader"
+    log "Leader: $LAST_LEADER"
+  fi
+  return 0
+}
+
+check_cluster_membership() {
+  [ -z "$LOCAL_IP" ] && return 0
+  local peers
+  peers=$(curl -sf --max-time 10 \
+    --cacert /etc/ssl/nomad/ca.pem \
+    --cert /etc/ssl/nomad/server.pem \
+    --key /etc/ssl/nomad/key.pem \
+    https://localhost:4646/v1/status/peers 2>/dev/null) || return 0
+  if ! echo "$peers" | grep -q "$LOCAL_IP"; then
+    log "This server ($LOCAL_IP) is not in the Nomad peer list: $peers"
+    return 1
+  fi
+  return 0
+}
+
+EC2_INSTANCE_ID=$(get_instance_id)
+LOCAL_IP=$(get_local_ip)
+log "Starting liveness check for instance $EC2_INSTANCE_ID ($LOCAL_IP)"
+
+for i in {1..30}; do
+  if check_nomad_installed; then
+    log "Nomad installed and active"
+    break
+  fi
+  log "Waiting for Nomad to be installed and active... ($i/30)"
+  sleep 30
+done
+
+if ! check_nomad_installed; then
+  log "Nomad failed to install within 15 minutes"
+  mark_unhealthy "Nomad failed to install"
+  exit 1
+fi
+
+while true; do
+  if ! check_nomad_installed; then
+    log "Nomad not installed or not active"
+    mark_unhealthy "Nomad not running"
+    FAILURE_COUNT=0
+    RESTART_COUNT=0
+    continue
+  fi
+
+  check_server_reachable
+  rc=$?
+  if [ "$rc" -eq 0 ]; then
+    if ! check_cluster_membership; then
+      mark_unhealthy "Server ejected from Nomad cluster"
+      FAILURE_COUNT=0
+      RESTART_COUNT=0
+    else
+      FAILURE_COUNT=0
+      RESTART_COUNT=0
+    fi
+  else
+    [ "$rc" -eq 2 ] && log "Quorum lost — no leader elected"
+    FAILURE_COUNT=$((FAILURE_COUNT + 1))
+    log "Server unreachable (failure $FAILURE_COUNT/$MAX_FAILURES)"
+    if [ "$FAILURE_COUNT" -ge "$MAX_FAILURES" ]; then
+      if [ "$RESTART_COUNT" -ge "$MAX_RESTARTS" ]; then
+        mark_unhealthy "Nomad failed $RESTART_COUNT restarts"
+        FAILURE_COUNT=0
+        RESTART_COUNT=0
+      else
+        RESTART_COUNT=$((RESTART_COUNT + 1))
+        log "Flushing DNS cache and restarting nomad (attempt $RESTART_COUNT/$MAX_RESTARTS)..."
+        resolvectl flush-caches
+        systemctl restart nomad
+        FAILURE_COUNT=0
+        log "Nomad restarted, waiting for stabilization"
+        sleep 120
+      fi
+    fi
+  fi
+  sleep $CHECK_INTERVAL
+done

--- a/nomad-aws/modules/nomad-server-aws/templates/nomad-server-startup.sh.tpl
+++ b/nomad-aws/modules/nomad-server-aws/templates/nomad-server-startup.sh.tpl
@@ -58,9 +58,55 @@ echo "--------------------------------------"
 apt-get install -y ntp
 
 echo "--------------------------------------"
+echo "  Creating ASG health reporter"
+echo "--------------------------------------"
+echo "${set_unhealthy_script}" | base64 -d > /usr/local/bin/nomad-set-unhealthy.sh
+chmod 0700 /usr/local/bin/nomad-set-unhealthy.sh
+
+echo "--------------------------------------"
+echo "  Creating nomad liveness check"
+echo "--------------------------------------"
+echo "${liveness_check_script}" | base64 -d > /usr/local/bin/nomad-liveness-check.sh
+chmod 0700 /usr/local/bin/nomad-liveness-check.sh
+
+cat <<EOT > /etc/systemd/system/nomad-liveness-check.service
+[Unit]
+Description=Nomad server liveness check
+After=network.target
+[Service]
+Type=simple
+Restart=always
+RestartSec=30
+StartLimitIntervalSec=3600
+StartLimitBurst=3
+ExecStart=/usr/local/bin/nomad-liveness-check.sh
+StandardOutput=journal
+StandardError=journal
+[Install]
+WantedBy=multi-user.target
+EOT
+
+systemctl daemon-reload
+systemctl enable --now nomad-liveness-check
+
+echo "--------------------------------------"
+echo "  Configuring log rotation"
+echo "--------------------------------------"
+cat <<EOT > /etc/logrotate.d/nomad-liveness-check
+/var/log/nomad-liveness-check.log {
+    daily
+    rotate 7
+    compress
+    missingok
+    notifempty
+    copytruncate
+}
+EOT
+
+echo "--------------------------------------"
 echo "Installing Nomad"
 echo "--------------------------------------"
-apt-get update && apt-get install -y wget gpg coreutils
+apt-get update && apt-get install -y wget gpg coreutils jq
 wget -O- https://apt.releases.hashicorp.com/gpg | gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
 echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
 sudo apt-get update
@@ -160,5 +206,6 @@ EOT
 echo "--------------------------------------"
 echo "      Starting Nomad service"
 echo "--------------------------------------"
+systemctl daemon-reload
 systemctl enable --now nomad
 systemctl status nomad

--- a/nomad-aws/modules/nomad-server-aws/templates/nomad-set-unhealthy.sh
+++ b/nomad-aws/modules/nomad-server-aws/templates/nomad-set-unhealthy.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+set -euo pipefail
+INSTANCE_ID=$1
+
+imds_get() {
+    curl -sf -H "X-aws-ec2-metadata-token: $TOKEN" \
+        "http://169.254.169.254/latest/meta-data/$1"
+}
+
+hmac_sha256() {
+    printf "%s" "$2" | openssl dgst -sha256 -mac HMAC -macopt "$1" -binary | od -An -tx1 | tr -d ' \n'
+}
+
+TOKEN=$(curl -sf -X PUT "http://169.254.169.254/latest/api/token" \
+    -H "X-aws-ec2-metadata-token-ttl-seconds: 60") || { echo "Failed to get IMDS token" >&2; exit 1; }
+
+REGION=$(imds_get "placement/region")
+ROLE=$(imds_get "iam/security-credentials/")
+read -r ACCESS_KEY SECRET_KEY SESSION_TOKEN < <(
+    imds_get "iam/security-credentials/$ROLE" | jq -r '[.AccessKeyId, .SecretAccessKey, .Token] | @tsv'
+)
+
+HOST="autoscaling.$REGION.amazonaws.com"
+AMZDATE=$(date -u +"%Y%m%dT%H%M%SZ")
+DATESTAMP=$(date -u +"%Y%m%d")
+BODY="Action=SetInstanceHealth&HealthStatus=Unhealthy&InstanceId=$INSTANCE_ID&Version=2011-01-01"
+PAYLOAD_HASH=$(printf "%s" "$BODY" | sha256sum | cut -d' ' -f1)
+
+CANONICAL_REQUEST=$(printf "POST\n/\n\ncontent-type:application/x-www-form-urlencoded\nhost:%s\nx-amz-date:%s\nx-amz-security-token:%s\n\ncontent-type;host;x-amz-date;x-amz-security-token\n%s" \
+    "$HOST" "$AMZDATE" "$SESSION_TOKEN" "$PAYLOAD_HASH")
+SCOPE="$DATESTAMP/$REGION/autoscaling/aws4_request"
+STRING_TO_SIGN=$(printf "AWS4-HMAC-SHA256\n%s\n%s\n%s" "$AMZDATE" "$SCOPE" \
+    "$(printf "%s" "$CANONICAL_REQUEST" | sha256sum | cut -d' ' -f1)")
+
+DATE_KEY=$(hmac_sha256 "key:AWS4$SECRET_KEY" "$DATESTAMP")
+REGION_KEY=$(hmac_sha256 "hexkey:$DATE_KEY" "$REGION")
+SERVICE_KEY=$(hmac_sha256 "hexkey:$REGION_KEY" "autoscaling")
+SIGNING_KEY=$(hmac_sha256 "hexkey:$SERVICE_KEY" "aws4_request")
+SIGNATURE=$(printf "%s" "$STRING_TO_SIGN" | openssl dgst -sha256 -mac HMAC -macopt "hexkey:$SIGNING_KEY" | sed 's/.* //')
+
+curl -sf --max-time 10 -X POST "https://$HOST/" \
+    -H "Content-Type: application/x-www-form-urlencoded" \
+    -H "X-Amz-Date: $AMZDATE" \
+    -H "X-Amz-Security-Token: $SESSION_TOKEN" \
+    -H "Authorization: AWS4-HMAC-SHA256 Credential=$ACCESS_KEY/$SCOPE, SignedHeaders=content-type;host;x-amz-date;x-amz-security-token, Signature=$SIGNATURE" \
+    -d "$BODY"


### PR DESCRIPTION
Enhance Nomad server healthcheck to reliably detect cluster health issues and ensure liveness monitoring continues even if Nomad installation fails.

  *Changes*

  - Quorum detection: Return exit code 2 when no leader is elected (vs. unreachable); log distinctly for cluster-wide failures
  - Cluster membership check: New check_cluster_membership() function validates this server is in /v1/status/peers; marks instance unhealthy if ejected from cluster
  - Fix restart loop: Reset RESTART_COUNT=0 after mark_unhealthy so restart attempts become available again after recovery
  - Fix bootstrap failure: Add exit 1 after install timeout to prevent script from falling into main loop