### PR TITLE
Backport IMDSv2 token fetch for SSH advertise IP (ONPREM-2370)

### DIFF
--- a/nomad-aws/template/nomad-startup.sh.tpl
+++ b/nomad-aws/template/nomad-startup.sh.tpl
@@ -1,14 +1,21 @@
 #!/bin/bash
 
-PRIVATE_IP="$(hostname --ip-address)"
-export PRIVATE_IP
-
 export DEBIAN_FRONTEND=noninteractive
 UNAME="$(uname -r)"
 export UNAME
 
+export aws_instance_metadata_url="http://169.254.169.254"
+export TOKEN="$(curl -X PUT "$aws_instance_metadata_url/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 180")"
+export PUBLIC_IP="$(curl -H "X-aws-ec2-metadata-token: $TOKEN" $aws_instance_metadata_url/latest/meta-data/public-ipv4)"
+export PRIVATE_IP="$(curl -H "X-aws-ec2-metadata-token: $TOKEN" $aws_instance_metadata_url/latest/meta-data/local-ipv4)"
+
+echo "PUBLIC_IP: $PUBLIC_IP"
+echo "PRIVATE_IP: $PRIVATE_IP"
+
 INSTANCE_ID=$(cloud-init query local_hostname)
 export INSTANCE_ID
+echo "INSTANCE_ID: $INSTANCE_ID"
+
 
 echo "----------------------------------------"
 echo "        Tuning kernel parameters"
@@ -72,14 +79,13 @@ sleep 5
 echo "--------------------------------------"
 echo " Populating /etc/circleci/public-ipv4"
 echo "--------------------------------------"
-export aws_instance_metadata_url="http://169.254.169.254"
-export PUBLIC_IP="$(curl $aws_instance_metadata_url/latest/meta-data/public-ipv4)"
-export PRIVATE_IP="$(curl $aws_instance_metadata_url/latest/meta-data/local-ipv4)"
+echo "Setting the IPv4 address below in /etc/circleci/public-ipv4."
+echo "This address will be used in builds with \"Rebuild with SSH\"."
+mkdir -p /etc/circleci
 if ! (echo $PUBLIC_IP | grep -qP "^[\d.]+$"); then
-    echo "Setting the IPv4 address below in /etc/circleci/public-ipv4."
-    echo "This address will be used in builds with \"Rebuild with SSH\"."
-    mkdir -p /etc/circleci
     echo $PRIVATE_IP | tee /etc/circleci/public-ipv4
+else
+    echo $PUBLIC_IP | tee /etc/circleci/public-ipv4
 fi
 
 echo "--------------------------------------"


### PR DESCRIPTION
## Summary

Backports [PR #238](https://github.com/CircleCI-Public/server-terraform/pull/238) / [ONPREM-2370](https://circleci.atlassian.net/browse/ONPREM-2370) to the `server-4.8` branch.

When Nomad client launch templates set `HttpTokens=required` (IMDSv2 only), the tokenless metadata curls in `nomad-aws/template/nomad-startup.sh.tpl` return empty values. The script then writes an empty `/etc/circleci/public-ipv4`, and Rerun with SSH fails with `failed to lookup ip`.

This change fetches an IMDSv2 session token before reading `public-ipv4` / `local-ipv4`, and seeds `/etc/circleci/public-ipv4` with the private IP when no public IP is assigned (same behavior as main/4.9.0).

## Context

- Fix already on `main` since July 2025; shipped in release tag `4.9.0`
- Server 4.8.x customers on IMDSv2-required executors need this without taking the full 4.9.0 module upgrade

## Test plan

- [ ] `terraform plan` against a representative 4.8.x nomad-aws module config shows only launch template user-data change
- [ ] Launch a Nomad client with `HttpTokens=required` and `assignPublicIP=false`; confirm `/etc/circleci/public-ipv4` contains the instance private IP after boot
- [ ] Rerun a Docker job with SSH succeeds and advertises the private IP

[ONPREM-2370]: https://circleci.atlassian.net/browse/ONPREM-2370?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ