### PR TITLE
Use StringLike for wildcard sub in nomad IRSA trust policy

### DIFF
--- a/nomad-aws/nomad-autoscaler.tf
+++ b/nomad-aws/nomad-autoscaler.tf
@@ -7,6 +7,11 @@ locals {
     ? substr(local.OIDC_EKS_VARIABLE, 0, length(local.OIDC_EKS_VARIABLE) - length(":sub"))
     : local.OIDC_EKS_VARIABLE
   )
+
+  # StringEquals treats "*" as a literal character, not a wildcard, so a
+  # wildcard k8s_service_account (e.g. "system:serviceaccount:*:nomad-autoscaler")
+  # must be matched with StringLike instead.
+  K8S_SERVICE_ACCOUNT_IS_WILDCARD = length(regexall("\\*", lookup(var.enable_irsa, "k8s_service_account", ""))) > 0
 }
 
 resource "aws_iam_user" "nomad_asg_user" {
@@ -39,6 +44,7 @@ resource "aws_iam_role" "nomad_role" {
     OIDC_PRINCIPAL_ID   = lookup(var.enable_irsa, "oidc_principal_id", "")
     OIDC_EKS_VARIABLE   = local.OIDC_EKS_VARIABLE_STRIPPED
     K8S_SERVICE_ACCOUNT = lookup(var.enable_irsa, "k8s_service_account", "")
+    SUB_IS_WILDCARD     = local.K8S_SERVICE_ACCOUNT_IS_WILDCARD
   })
 
   inline_policy {

--- a/nomad-aws/template/nomad_irsa_trust_policy.tpl
+++ b/nomad-aws/template/nomad_irsa_trust_policy.tpl
@@ -9,10 +9,19 @@
             },
             "Action": "sts:AssumeRoleWithWebIdentity",
             "Condition": {
+%{ if SUB_IS_WILDCARD }
+                "StringEquals": {
+                "${OIDC_EKS_VARIABLE}:aud": "sts.amazonaws.com"
+                },
+                "StringLike": {
+                "${OIDC_EKS_VARIABLE}:sub": "${K8S_SERVICE_ACCOUNT}"
+                }
+%{ else }
                 "StringEquals": {
                 "${OIDC_EKS_VARIABLE}:aud": "sts.amazonaws.com",
                 "${OIDC_EKS_VARIABLE}:sub": "${K8S_SERVICE_ACCOUNT}"
                 }
+%{ endif }
             }
         }
 


### PR DESCRIPTION
  - `nomad-aws/nomad-autoscaler.tf`: add K8S_SERVICE_ACCOUNT_IS_WILDCARD local, detect * in k8s_service_account via regex, pass as SUB_IS_WILDCARD to the trust policy template.
  - `nomad-aws/template/nomad_irsa_trust_policy.tpl`: split the :sub condition into StringLike when wildcarded, StringEquals otherwise — StringEquals treats * as literal, so a wildcard SA pattern
  (system:serviceaccount:*:nomad-autoscaler) never actually matched and caused AssumeRoleWithWebIdentity to fail with AccessDenied.