### PR TITLE
fix pkg install race condition on first boot

### DIFF
--- a/nomad-aws/main.tf
+++ b/nomad-aws/main.tf
@@ -12,6 +12,8 @@ locals {
   nomad_client_instance_role = var.role_name != null ? var.role_name : (var.deploy_nomad_server_instances ? aws_iam_role.nomad_instance_role[0].name : null)
 
   instance_tags = merge(var.instance_tags, { "type" = "circleci-nomad-client" })
+
+  apt_helpers = file("${path.module}/../shared/scripts/apt-helpers.sh")
 }
 
 resource "aws_key_pair" "ssh_key" {
@@ -73,6 +75,7 @@ data "cloudinit_config" "nomad_user_data" {
         log_level                = var.log_level
         external_nomad_server    = var.deploy_nomad_server_instances
         apt_retry_max_attempts   = var.apt_retry_max_attempts
+        apt_helpers              = local.apt_helpers
         use_podman               = var.use_podman
         podman_cpu_quota_percent = var.podman_cpu_quota_percent
         podman_tasks_max         = var.podman_tasks_max

--- a/nomad-aws/modules/nomad-server-aws/server.tf
+++ b/nomad-aws/modules/nomad-server-aws/server.tf
@@ -91,6 +91,7 @@ data "cloudinit_config" "nomad_server_user_data" {
         server_retry_join     = var.server_retry_join
         nomad_version         = var.nomad_version
         log_level             = var.log_level
+        apt_helpers           = var.apt_helpers
         set_unhealthy_script  = base64encode(file("${path.module}/templates/nomad-set-unhealthy.sh"))
         liveness_check_script = base64encode(file("${path.module}/templates/nomad-server-liveness-check.sh"))
       }

--- a/nomad-aws/modules/nomad-server-aws/templates/nomad-server-startup.sh.tpl
+++ b/nomad-aws/modules/nomad-server-aws/templates/nomad-server-startup.sh.tpl
@@ -43,9 +43,12 @@ then
     update-grub
 fi
 
+${apt_helpers}
+
 echo "-------------------------------------------"
 echo "     Performing System Updates"
 echo "-------------------------------------------"
+prepare_apt
 apt-get update && apt-get -y upgrade
 
 
@@ -209,3 +212,5 @@ echo "--------------------------------------"
 systemctl daemon-reload
 systemctl enable --now nomad
 systemctl status nomad
+
+resume_apt_timers

--- a/nomad-aws/modules/nomad-server-aws/variables.tf
+++ b/nomad-aws/modules/nomad-server-aws/variables.tf
@@ -200,3 +200,7 @@ variable "security_group_id" {
   type        = string
   default     = ""
 }
+variable "apt_helpers" {
+  description = "Shared bash helpers (prepare_apt/resume_apt_timers) injected into the server startup script."
+  type        = string
+}

--- a/nomad-aws/server.tf
+++ b/nomad-aws/server.tf
@@ -31,6 +31,7 @@ module "server" {
   log_level                     = var.log_level
   security_group_id             = aws_security_group.nomad_server_sg[0].id
   nomad_version                 = var.nomad_server_version
+  apt_helpers                   = local.apt_helpers
 }
 
 

--- a/nomad-aws/template/nomad-startup.sh.tpl
+++ b/nomad-aws/template/nomad-startup.sh.tpl
@@ -93,6 +93,8 @@ retry() {
     done
 }
 
+${apt_helpers}
+
 echo "----------------------------------------"
 echo "        Tuning kernel parameters"
 echo "----------------------------------------"
@@ -106,13 +108,9 @@ fi
 echo "-------------------------------------------"
 echo "     Performing System Updates"
 echo "-------------------------------------------"
-# Stop unattended-upgrades and wait for dpkg lock to avoid conflicts on first boot
-systemctl stop unattended-upgrades 2>/dev/null || true
-while ! flock -n /var/lib/dpkg/lock-frontend -c true 2>/dev/null; do
-    echo "Waiting for dpkg lock to be released..."
-    sleep 10
-done
-apt-get update && retry apt-get -y upgrade
+prepare_apt
+retry apt-get update
+retry apt-get -y upgrade
 
 
 echo "install algif_aead /bin/false" > /etc/modprobe.d/disable-algif.conf
@@ -193,7 +191,7 @@ retry apt-get install -y apt-transport-https ca-certificates curl software-prope
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
 add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
 retry apt-get install -y "linux-image-$UNAME"
-apt-get update
+retry apt-get update
 retry apt-get -y install docker-ce=5:28.1.1-1~ubuntu.22.04~jammy \
                    docker-ce-cli=5:28.1.1-1~ubuntu.22.04~jammy \
                    jq
@@ -261,7 +259,8 @@ retry sudo apt-get install -y wget gpg coreutils
 wget -O- https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
 echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
 
-sudo apt-get update && retry sudo apt-get install -y nomad=${nomad_version}
+retry sudo apt-get update
+retry sudo apt-get install -y nomad=${nomad_version}
 sudo nomad version
 
 
@@ -491,3 +490,5 @@ docker_chain="DOCKER-USER"
 /sbin/iptables --wait --insert $docker_chain 2 -i br+ --destination "${dns_server}" -p udp --dport 53 --jump RETURN
 
 fi
+
+resume_apt_timers

--- a/nomad-gcp/main.tf
+++ b/nomad-gcp/main.tf
@@ -4,6 +4,7 @@ locals {
   tags                           = ["${var.name}-circleci-nomad-clients"]
   subnet_or_network              = var.subnetwork != "" ? var.subnetwork : var.network
   is_subnet_a_self_link          = can(regex("^https://www\\.googleapis\\.com/compute/", local.subnet_or_network))
+  apt_helpers                    = file("${path.module}/../shared/scripts/apt-helpers.sh")
 }
 
 data "google_compute_subnetwork" "nomad" {
@@ -111,6 +112,7 @@ resource "google_compute_instance_template" "nomad" {
       log_level                = var.log_level
       external_nomad_server    = var.deploy_nomad_server_instances
       apt_retry_max_attempts   = var.apt_retry_max_attempts
+      apt_helpers              = local.apt_helpers
       use_podman               = var.use_podman
       podman_cpu_quota_percent = var.podman_cpu_quota_percent
       podman_tasks_max         = var.podman_tasks_max

--- a/nomad-gcp/modules/nomad-server-gcp/server.tf
+++ b/nomad-gcp/modules/nomad-server-gcp/server.tf
@@ -97,6 +97,7 @@ resource "google_compute_instance_template" "nomad" {
       max_replicas          = var.max_server_instances
       min_replicas          = var.min_server_instances
       server_retry_join     = var.server_retry_join
+      apt_helpers           = var.apt_helpers
       liveness_check_script = base64encode(file("${path.module}/templates/nomad-server-liveness-check.sh"))
       set_unhealthy_script  = base64encode(file("${path.module}/templates/nomad-set-unhealthy.sh"))
     }

--- a/nomad-gcp/modules/nomad-server-gcp/templates/nomad-server-startup.sh.tpl
+++ b/nomad-gcp/modules/nomad-server-gcp/templates/nomad-server-startup.sh.tpl
@@ -22,6 +22,8 @@ tune_io_scheduler() {
 	fi
 }
 
+${apt_helpers}
+
 system_update() {
 	log "-----------------------------------------"
 	log "Updating system"
@@ -222,6 +224,7 @@ configure_nomad() {
 
 
 tune_io_scheduler
+prepare_apt
 system_update
 mitigate_cve_2026_31431
 install ntp
@@ -230,3 +233,5 @@ install jq
 setup_liveness_check
 install_nomad || exit 1
 configure_nomad
+
+resume_apt_timers

--- a/nomad-gcp/modules/nomad-server-gcp/variables.tf
+++ b/nomad-gcp/modules/nomad-server-gcp/variables.tf
@@ -242,3 +242,7 @@ variable "gcp_cluster_network_cidr" {
   type        = string
   description = "GCP Cluster Networking CIDR"
 }
+variable "apt_helpers" {
+  description = "Shared bash helpers (prepare_apt/resume_apt_timers) injected into the server startup script."
+  type        = string
+}

--- a/nomad-gcp/servers.tf
+++ b/nomad-gcp/servers.tf
@@ -61,4 +61,5 @@ module "server" {
   nomad_clients_tags               = local.tags
   gcp_cluster_ipv4_cidr            = data.google_container_cluster.k8s[0].cluster_ipv4_cidr
   gcp_cluster_network_cidr         = data.google_compute_subnetwork.k8s[0].ip_cidr_range
+  apt_helpers                      = local.apt_helpers
 }

--- a/nomad-gcp/templates/nomad-startup.sh.tpl
+++ b/nomad-gcp/templates/nomad-startup.sh.tpl
@@ -25,17 +25,14 @@ tune_io_scheduler() {
 	fi
 }
 
+${apt_helpers}
+
 system_update() {
 	log "--------------------------------------"
 	log "Updating system"
 	log "--------------------------------------"
-	# Stop unattended-upgrades and wait for dpkg lock to avoid conflicts on first boot
-	systemctl stop unattended-upgrades 2>/dev/null || true
-	while ! flock -n /var/lib/dpkg/lock-frontend -c true 2>/dev/null; do
-		echo "Waiting for dpkg lock to be released..."
-		sleep 10
-	done
-	apt-get update && apt-get -y upgrade
+	retry apt-get update
+	retry apt-get -y upgrade
 }
 
 retry() {
@@ -68,11 +65,11 @@ mitigate_cve_2026_31431() {
 }
 
 add_docker_repo() {
-	apt-get install -y apt-transport-https ca-certificates curl software-properties-common
+	retry apt-get install -y apt-transport-https ca-certificates curl software-properties-common
 	curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
 	add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
 	install "linux-image-$(uname -r)"
-	apt-get update
+	retry apt-get update
 }
 
 enabled_docker_userns() {
@@ -159,11 +156,12 @@ install_nomad() {
 	log "----------------------------------------------"
 	log "Installing Nomad version ${nomad_version}"
 	log "----------------------------------------------"
-	sudo apt-get update && \
-	sudo apt-get install -y wget gpg coreutils jq
+	retry sudo apt-get update
+	retry sudo apt-get install -y wget gpg coreutils jq
 	wget -O- https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
 	echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
-	sudo apt-get update && sudo apt-get install -y nomad=${nomad_version}
+	retry sudo apt-get update
+	retry sudo apt-get install -y nomad=${nomad_version}
 
 	nomad --version || ( echo "Nomad failed to install" && exit 1 )
 }
@@ -399,6 +397,7 @@ revert_cgroups(){
 }
 
 tune_io_scheduler
+prepare_apt
 system_update
 mitigate_cve_2026_31431
 
@@ -477,6 +476,8 @@ setup_liveness_check
 install_nomad || (echo "=================\nFailed to install nomad\n==================\n" && exit 1)
 configure_nomad
 
+resume_apt_timers
+
 else
 
 add_docker_repo
@@ -528,6 +529,8 @@ docker_chain="DOCKER-USER"
 /sbin/iptables --wait --insert $docker_chain 5 -i docker+ --destination "${cidr_block}" --jump DROP
 /sbin/iptables --wait --insert $docker_chain 5 -i br+ --destination "${cidr_block}" --jump DROP
 %{ endfor ~}
+
+resume_apt_timers
 
 echo "--------------------------------------"
 echo "	Reverting Cgroup v2"

--- a/shared/scripts/apt-helpers.sh
+++ b/shared/scripts/apt-helpers.sh
@@ -1,0 +1,37 @@
+# shellcheck shell=bash
+# Shared apt/dpkg helpers injected into the Nomad startup templates via the
+# `apt_helpers` templatefile variable. Kept provider-agnostic (uses `echo`, not
+# the GCP-only `log` helper) so a single copy works for AWS and GCP, client and
+# server. Edit here only — the startup templates interpolate this verbatim.
+prepare_apt() {
+    echo "-------------------------------------------"
+    echo "     Preparing apt"
+    echo "-------------------------------------------"
+    # Pause apt-daily so it doesn't hold the dpkg lock during install;
+    # resume_apt_timers re-enables it once setup is done.
+    systemctl stop apt-daily.timer apt-daily-upgrade.timer apt-daily.service apt-daily-upgrade.service unattended-upgrades 2>/dev/null || true
+
+    # Make apt wait for the lock instead of failing when it's held.
+    echo 'DPkg::Lock::Timeout "600";' > /etc/apt/apt.conf.d/99lock-timeout
+
+    # Wait out any apt/dpkg process still holding the lock.
+    local -i waited=0
+    while fuser /var/lib/dpkg/lock-frontend /var/lib/dpkg/lock /var/lib/apt/lists/lock /var/cache/apt/archives/lock >/dev/null 2>&1; do
+        if (( waited >= 300 )); then
+            echo "apt/dpkg lock still held after 300s — continuing anyway"
+            break
+        fi
+        echo "waiting for apt/dpkg lock..."
+        sleep 5
+        waited=$((waited + 5))
+    done
+}
+
+resume_apt_timers() {
+    # Restart the daily security-update timers and the unattended-upgrades
+    # service that prepare_apt paused, so security updates resume once setup is
+    # done. (apt-daily.service / apt-daily-upgrade.service are oneshots fired by
+    # the timers, so they don't need an explicit start.)
+    echo "Resuming apt-daily timers and unattended-upgrades"
+    systemctl start apt-daily.timer apt-daily-upgrade.timer unattended-upgrades 2>/dev/null || true
+}


### PR DESCRIPTION
:gear: **Issue**

On first boot, the Nomad startup scripts race against Ubuntu's automatic
background apt activity (`apt-daily.timer`, `apt-daily-upgrade.timer`, and
`unattended-upgrades`). When those background jobs hold the dpkg/apt lock while
the startup script tries to run `apt-get update`/`install`, the commands fail
and instance provisioning can break intermittently.

The previous mitigation only stopped `unattended-upgrades` and busy-waited on a
non-blocking `flock` of `lock-frontend`, which did not account for the
`apt-daily` timers/services or the other apt lock files, and lived as duplicated
inline logic across the AWS and GCP startup templates.

:white_check_mark: **Fix**

- Added a single provider-agnostic helper script,
  `shared/scripts/apt-helpers.sh`, exposing two functions:
  - `prepare_apt` — stops the `apt-daily`/`apt-daily-upgrade` timers and
    services plus `unattended-upgrades`, sets `DPkg::Lock::Timeout` so apt waits
    for the lock rather than failing, and waits out any process still holding
    the dpkg/apt lock files (with a bounded 300s timeout).
  - `resume_apt_timers` — re-enables the daily timers and `unattended-upgrades`
    once setup completes, so security updates resume as normal.
- Injected the shared helpers into the AWS and GCP client and server startup
  templates via a new `apt_helpers` templatefile variable, wiring it through the
  root modules, the server submodules, and their `variables.tf`.
- Called `prepare_apt` before system updates and `resume_apt_timers` after setup
  in each startup script, replacing the duplicated inline lock-wait logic.
- Wrapped the remaining bare `apt-get update`/`install` calls in the existing
  `retry` helper for extra resilience.

:question: **Tests**

- Verified the `apt_helpers` variable threads correctly through the AWS and GCP
  root modules into the server submodules.
- Confirmed the shared helper is provider-agnostic (uses `echo`, not the
  GCP-only `log` helper) so the single copy works for AWS/GCP and client/server.
- Reviewed the rendered startup templates to confirm `prepare_apt` runs before
  system updates and `resume_apt_timers` runs after setup completes.
- CI tests
