### PR TITLE
Fix: Allow aws iam role to set nomad client's health

### DIFF
--- a/nomad-aws/template/nomad_asg_policy.tpl
+++ b/nomad-aws/template/nomad_asg_policy.tpl
@@ -9,7 +9,8 @@
                 "autoscaling:UpdateAutoScalingGroup",
                 "autoscaling:TerminateInstanceInAutoScalingGroup",
                 "autoscaling:DescribeAutoScalingGroups",
-				"autoscaling:DescribeScalingActivities"
+				"autoscaling:DescribeScalingActivities",
+                "autoscaling:SetInstanceHealth"
             ],
             "Resource": "${ASG_ARN}"
         },


### PR DESCRIPTION
- Allowing Nomad Client IAM role to update the instance health if healthcheck is failing 
- Fixing drift alert (slack notification)